### PR TITLE
Fix L-BFGS

### DIFF
--- a/lbfgs.go
+++ b/lbfgs.go
@@ -1,8 +1,6 @@
 package optimize
 
 import (
-	"math"
-
 	"github.com/gonum/floats"
 )
 
@@ -102,9 +100,7 @@ func (l *LBFGS) InitDirection(loc Location, direction []float64) (stepSize float
 	copy(direction, loc.Gradient)
 	floats.Scale(-1, direction)
 
-	// see BFGS for comment
-	floats.Scale(1/math.Sqrt(floats.Norm(direction, 2)), direction)
-	return 1
+	return 1 / floats.Norm(direction, 2)
 }
 
 func (l *LBFGS) NextDirection(loc Location, direction []float64) (stepSize float64) {


### PR DESCRIPTION
This PR fixes a bug in the computation of the descent direction and modifies the step size on the first iteration.

The bug was in updating the L-BFGS history which was basically one iteration off. Consequently, the generated descent directions were not correct and too many iterations and function/gradient evaluations were necessary for convergence. Fixing this bug reduces the stats to some 38 iterations and 60 function evaluations for the Rosenbrock function from (-1.2,1).

Also, the step size on the first iteration is modified so that the first attempted step is in fact the _normalized_ steepest descent step. This is consistent with other optimization codes, e.g., with the original Nocedal's L-BFGS code. Furhermore, it improves the performance on the above test problem to some 34 iterations and 45 function evaluations which are very reasonable and expected numbers.
