### PR TITLE
Modify Stats.GradientNorm and the gradient convergence check

### DIFF
--- a/local.go
+++ b/local.go
@@ -240,7 +240,7 @@ func getStartingLocation(f Function, funcs functions, funcInfo *FunctionInfo, in
 
 func checkConvergence(loc Location, itertype IterationType, stats *Stats, settings *Settings) Status {
 	if itertype == MajorIteration && loc.Gradient != nil {
-		if stats.GradientNormInf <= settings.GradientAbsTol {
+		if stats.GradientNorm <= settings.GradientAbsTol {
 			return GradientAbsoluteConvergence
 		}
 	}
@@ -347,7 +347,6 @@ func update(location Location, optLoc *Location, stats *Stats, funcInfo *Functio
 	}
 	stats.Runtime = time.Since(startTime)
 	if location.Gradient != nil {
-		stats.GradientNorm = floats.Norm(location.Gradient, 2)
-		stats.GradientNormInf = floats.Norm(location.Gradient, math.Inf(1))
+		stats.GradientNorm = floats.Norm(location.Gradient, math.Inf(1))
 	}
 }

--- a/printer.go
+++ b/printer.go
@@ -40,7 +40,7 @@ var (
 		"Iter",
 		"FunEval",
 		"Obj",
-		"GradNormInf",
+		"GradNorm",
 	}
 )
 
@@ -71,7 +71,7 @@ func (p *Printer) Record(l Location, eval EvaluationType, iter IterationType, st
 	valueStrings[1] = strconv.Itoa(stats.FunctionEvals + stats.FunctionGradientEvals)
 	valueStrings[2] = fmt.Sprintf("%g", l.F)
 	if p.printGrad {
-		valueStrings[3] = fmt.Sprintf("%g", stats.GradientNormInf)
+		valueStrings[3] = fmt.Sprintf("%g", stats.GradientNorm)
 	}
 
 	var maxLengths [nPrinterOut]int

--- a/types.go
+++ b/types.go
@@ -83,8 +83,7 @@ type Stats struct {
 	GradientEvals         int           // Number of evaluations of Df()
 	FunctionGradientEvals int           // Number of evaluations of FDf()
 	Runtime               time.Duration // Total runtime of the optimization
-	GradientNorm          float64       // 2-norm of the gradient
-	GradientNormInf       float64       // Maximum norm of the gradient
+	GradientNorm          float64       // Infinity norm of the gradient
 }
 
 // FunctionInfo is data to give to the optimizer about the objective function.


### PR DESCRIPTION
Remove division by sqrt(dim) in the computation of Stats.GradientNorm because:
- The name of the field is misleading otherwise
- Stats.GradientNorm is reported by Printer which then also becomes misleading
- The division is unnecessary; dimension of the problem is readily available if someone needs the divided value
- Using such modified gradient norm seems non-standard in gradient convergence checks

Add GradientNormInf to Stats

Use the maximum norm of the gradient in the convergence check, it seems more standard than the 2-norm, and modify Printer to show the max-norm instead of the 2-norm.

Point to consider: it would be much more natural to move GradientNorm and GradientNormInf to Location and update it in evaluate().
