### PR TITLE
Add sanity checks to Bisection and Backtracking

### DIFF
--- a/backtracking.go
+++ b/backtracking.go
@@ -16,7 +16,7 @@ const (
 // been met, the step size is decreased by a factor of Decrease.
 //
 // The Armijo conditions only require the gradient at the initial condition
-// (not successive step locatinons), and so Backtracking may be a good linesearch
+// (not successive step locations), and so Backtracking may be a good linesearch
 // method for functions with expensive gradients. Backtracking is not appropriate
 // for optimizers that require the Wolfe conditions to be met, such as BFGS.
 //
@@ -33,18 +33,21 @@ type Backtracking struct {
 }
 
 func (b *Backtracking) Init(initLoc LinesearchLocation, initStepSize float64, f *FunctionInfo) EvaluationType {
+	if initStepSize <= 0 {
+		panic("backtracking: bad step size")
+	}
+	if initLoc.Derivative >= 0 {
+		panic("Backtracking: init G non-negative")
+	}
+
 	if b.Decrease == 0 {
 		b.Decrease = defaultBacktrackingDecrease
 	}
 	if b.FunConst == 0 {
 		b.FunConst = defaultBacktrackingFunConst
 	}
-	if initStepSize < 0 {
-		panic("backtracking: bad step size")
-	}
-
 	if b.Decrease <= 0 || b.Decrease >= 1 {
-		panic("backtracking: decrease must be between 0 and 1")
+		panic("backtracking: Decrease must be between 0 and 1")
 	}
 	if b.FunConst <= 0 || b.FunConst >= 1 {
 		panic("backtracking: FunConst must be between 0 and 1")

--- a/bisection.go
+++ b/bisection.go
@@ -31,14 +31,17 @@ type Bisection struct {
 }
 
 func (b *Bisection) Init(initLoc LinesearchLocation, initStepSize float64, f *FunctionInfo) EvaluationType {
-	if initLoc.Derivative > 0 {
-		panic("bisection: init G greater than 0")
+	if initLoc.Derivative >= 0 {
+		panic("bisection: init G non-negative")
+	}
+	if initStepSize <= 0 {
+		panic("bisection: bad step size")
 	}
 
 	if b.GradConst == 0 {
 		b.GradConst = 0.9
 	}
-	if b.GradConst <= 0 || b.GradConst > 1 {
+	if b.GradConst <= 0 || b.GradConst >= 1 {
 		panic("bisection: GradConst not between 0 and 1")
 	}
 

--- a/linesearch.go
+++ b/linesearch.go
@@ -38,7 +38,7 @@ func (l *Linesearch) Init(loc Location, f *FunctionInfo, xNext []float64) (Evalu
 	projGrad := math.NaN()
 	if loc.Gradient != nil {
 		projGrad = floats.Dot(loc.Gradient, l.direction)
-		if projGrad > 0 {
+		if projGrad >= 0 {
 			return NoEvaluation, NoIteration, ErrNonNegativeStepDirection
 		}
 	}
@@ -100,7 +100,7 @@ func (l *Linesearch) initNextLinesearch(loc Location, xNext []float64) (Evaluati
 	if loc.Gradient != nil {
 		projGrad = floats.Dot(loc.Gradient, l.direction)
 	}
-	if projGrad > 0 {
+	if projGrad >= 0 {
 		return NoEvaluation, NoIteration, ErrNonNegativeStepDirection
 	}
 	initLinesearchLocation := LinesearchLocation{


### PR DESCRIPTION
- Add sanity checks to Bisection and Backtracking
- Make the test for descent direction in linesearch.go stricter and consistent with Bisection and Backtracking
- Fix some typos

The change from projGrad > 0 to a stricter projGrad >= 0 should definitely be done. This condition is tested in linesearch.go immediately after getting a new direction from NextDirectioner. I think that NextDirectioners should simply try everything possible not to return non-descent directions.

The tests pass.
