### PR TITLE
Add Shanno-Phua initial step size

### DIFF
--- a/stepsizers.go
+++ b/stepsizers.go
@@ -41,19 +41,20 @@ func (c ConstantStepSize) StepSize(l Location, dir []float64) float64 {
 // descent directions, such as gradient descent or conjugate gradient methods.
 // The step size is bounded away from zero.
 type QuadraticStepSize struct {
-	// If the relative change in the objective function is larger than
-	// Threshold, the step size is estimated by quadratic interpolation,
-	// otherwise it is set to 2*previous step size.
-	// The default value is 1e-12.
+	// Threshold determines that the initial step size should be estimated by
+	// quadratic interpolation when the relative change in the objective
+	// function is larger than Threshold.  Otherwise the initial step size is
+	// set to 2*previous step size.
+	// If Threshold is zero, it will be set to 1e-12.
 	Threshold float64
-	// The step size at the first iteration is estimated as InitialStepFactor / |g|_∞.
+	// InitialStepFactor sets the step size for the first iteration to be InitialStepFactor / |g|_∞.
 	// If InitialStepFactor is zero, it will be set to one.
 	InitialStepFactor float64
-	// The estimated step size is always greater than or equal to MinStepSize.
+	// MinStepSize is the lower bound on the estimated step size.
 	// MinStepSize times GradientAbsTol should always be greater than machine epsilon.
 	// If MinStepSize is zero, it will be set to 1e-3.
 	MinStepSize float64
-	// The estimated step size is always lower than or equal to MaxStepSize.
+	// MaxStepSize is the upper bound on the estimated step size.
 	// If MaxStepSize is zero, it will be set to 1.01.
 	MaxStepSize float64
 
@@ -127,14 +128,14 @@ func (q *QuadraticStepSize) StepSize(l Location, dir []float64) (stepSize float6
 // This is useful for line search methods that do not produce well-scaled
 // descent directions, such as gradient descent or conjugate gradient methods.
 type FirstOrderStepSize struct {
-	// The step size at the first iteration is estimated as InitialStepFactor / |g|_∞.
+	// InitialStepFactor sets the step size for the first iteration to be InitialStepFactor / |g|_∞.
 	// If InitialStepFactor is zero, it will be set to one.
 	InitialStepFactor float64
-	// The estimated step size is always greater than or equal to MinStepSize.
+	// MinStepSize is the lower bound on the estimated step size.
 	// MinStepSize times GradientAbsTol should always be greater than machine epsilon.
 	// If MinStepSize is zero, it will be set to 1e-3.
 	MinStepSize float64
-	// The estimated step size is always lower than or equal to MaxStepSize.
+	// MaxStepSize is the upper bound on the estimated step size.
 	// If MaxStepSize is zero, it will be set to 1.01.
 	MaxStepSize float64
 

--- a/stepsizers.go
+++ b/stepsizers.go
@@ -157,7 +157,7 @@ func (fo *FirstOrderStepSize) Init(l Location, dir []float64) (stepSize float64)
 	if fo.MaxStepSize == 0 {
 		fo.MaxStepSize = firstOrderMaximumStepSize
 	}
-	if q.MaxStepSize <= q.MinStepSize {
+	if fo.MaxStepSize <= fo.MinStepSize {
 		panic("optimize: MinStepSize not smaller than MaxStepSize")
 	}
 

--- a/stepsizers.go
+++ b/stepsizers.go
@@ -119,6 +119,13 @@ func (q *QuadraticStepSize) StepSize(l Location, dir []float64) (stepSize float6
 	return stepSize
 }
 
+// FirstOrderStepSize estimates the initial line search step size based on the
+// assumption that the first-order change in the function will be the same as
+// that obtained at the previous iteration. That is, the initial step size s^0_k
+// is chosen so that
+//   s^0_k ∇f_k⋅p_k = s_{k-1} ∇f_{k-1}⋅p_{k-1}
+// This is useful for line search methods that do not produce well-scaled
+// descent directions, such as gradient descent or conjugate gradient methods.
 type FirstOrderStepSize struct {
 	// The step size at the first iteration is estimated as InitialStepFactor / |g|_∞.
 	// If InitialStepFactor is zero, it will be set to one.

--- a/stepsizers.go
+++ b/stepsizers.go
@@ -65,7 +65,6 @@ type QuadraticStepSize struct {
 }
 
 func (q *QuadraticStepSize) Init(l Location, dir []float64) (stepSize float64) {
-	q.xPrev = resize(q.xPrev, len(l.X))
 	if q.Threshold == 0 {
 		q.Threshold = quadraticThreshold
 	}
@@ -78,6 +77,9 @@ func (q *QuadraticStepSize) Init(l Location, dir []float64) (stepSize float64) {
 	if q.MaxStepSize == 0 {
 		q.MaxStepSize = quadraticMaximumStepSize
 	}
+	if q.MaxStepSize <= q.MinStepSize {
+		panic("optimize: MinStepSize not smaller than MaxStepSize")
+	}
 
 	gNorm := floats.Norm(l.Gradient, math.Inf(1))
 	stepSize = math.Max(q.MinStepSize, math.Min(q.InitialStepFactor/gNorm, q.MaxStepSize))
@@ -85,6 +87,7 @@ func (q *QuadraticStepSize) Init(l Location, dir []float64) (stepSize float64) {
 	q.fPrev = l.F
 	q.dirPrevNorm = floats.Norm(dir, 2)
 	q.projGradPrev = floats.Dot(l.Gradient, dir)
+	q.xPrev = resize(q.xPrev, len(l.X))
 	copy(q.xPrev, l.X)
 	return stepSize
 }
@@ -145,7 +148,6 @@ type FirstOrderStepSize struct {
 }
 
 func (fo *FirstOrderStepSize) Init(l Location, dir []float64) (stepSize float64) {
-	fo.xPrev = resize(fo.xPrev, len(l.X))
 	if fo.InitialStepFactor == 0 {
 		fo.InitialStepFactor = initialStepFactor
 	}
@@ -155,12 +157,16 @@ func (fo *FirstOrderStepSize) Init(l Location, dir []float64) (stepSize float64)
 	if fo.MaxStepSize == 0 {
 		fo.MaxStepSize = firstOrderMaximumStepSize
 	}
+	if q.MaxStepSize <= q.MinStepSize {
+		panic("optimize: MinStepSize not smaller than MaxStepSize")
+	}
 
 	gNorm := floats.Norm(l.Gradient, math.Inf(1))
 	stepSize = math.Max(fo.MinStepSize, math.Min(fo.InitialStepFactor/gNorm, fo.MaxStepSize))
 
 	fo.dirPrevNorm = floats.Norm(dir, 2)
 	fo.projGradPrev = floats.Dot(l.Gradient, dir)
+	fo.xPrev = resize(fo.xPrev, len(l.X))
 	copy(fo.xPrev, l.X)
 	return stepSize
 }

--- a/stepsizers.go
+++ b/stepsizers.go
@@ -14,7 +14,7 @@ const (
 	initialStepFactor = 1
 
 	quadraticMinimumStepSize = 1e-3
-	quadraticMaximumStepSize = 1.01
+	quadraticMaximumStepSize = 1
 	quadraticThreshold       = 1e-12
 
 	firstOrderMinimumStepSize = quadraticMinimumStepSize
@@ -55,7 +55,7 @@ type QuadraticStepSize struct {
 	// If MinStepSize is zero, it will be set to 1e-3.
 	MinStepSize float64
 	// MaxStepSize is the upper bound on the estimated step size.
-	// If MaxStepSize is zero, it will be set to 1.01.
+	// If MaxStepSize is zero, it will be set to 1.
 	MaxStepSize float64
 
 	fPrev        float64
@@ -136,7 +136,7 @@ type FirstOrderStepSize struct {
 	// If MinStepSize is zero, it will be set to 1e-3.
 	MinStepSize float64
 	// MaxStepSize is the upper bound on the estimated step size.
-	// If MaxStepSize is zero, it will be set to 1.01.
+	// If MaxStepSize is zero, it will be set to 1.
 	MaxStepSize float64
 
 	dirPrevNorm  float64


### PR DESCRIPTION
* Implemented the other initial step size strategy described in Nocedal&Wright
* In some CG implementations the formula is attributed to Shanno&Phua, but for consistence with QuadraticStepSize the type's name FirstOrderStepSize rather refers to how the step size is estimated. ShannoPhuaStepSize is an alternative name anyway.
* This strategy seems to generate step size that work better with CG than those generated by QuadraticStepSize
* #16 should be reviewed and merged first