### PR TITLE
Handle NoEvaluation in evaluate()

### DIFF
--- a/types.go
+++ b/types.go
@@ -47,6 +47,9 @@ const (
 )
 
 func (i IterationType) String() string {
+	if i < 0 || int(i) >= len(iterationStrings) {
+		return fmt.Sprintf("IterationType(%d)", i)
+	}
 	return iterationStrings[i]
 }
 

--- a/types.go
+++ b/types.go
@@ -5,6 +5,7 @@
 package optimize
 
 import (
+	"fmt"
 	"math"
 	"time"
 )
@@ -21,6 +22,9 @@ const (
 )
 
 func (e EvaluationType) String() string {
+	if e < 0 || int(e) >= len(evaluationStrings) {
+		return fmt.Sprintf("EvaluationType(%d)", e)
+	}
 	return evaluationStrings[e]
 }
 


### PR DESCRIPTION
Currently, evaluate() panics when `evalType == NoEvaluation`. Also, location.X is modified even when evalType is not supported and no evaluation takes place. This PR fixes both issues and improves the comment for evaluate().