### PR TITLE
Unify variable names

### DIFF
--- a/backtracking.go
+++ b/backtracking.go
@@ -32,11 +32,11 @@ type Backtracking struct {
 	initG    float64
 }
 
-func (b *Backtracking) Init(initLoc LinesearchLocation, initStepSize float64, f *FunctionInfo) EvaluationType {
-	if initStepSize <= 0 {
+func (b *Backtracking) Init(loc LinesearchLocation, step float64, _ *FunctionInfo) EvaluationType {
+	if step <= 0 {
 		panic("backtracking: bad step size")
 	}
-	if initLoc.Derivative >= 0 {
+	if loc.Derivative >= 0 {
 		panic("Backtracking: init G non-negative")
 	}
 
@@ -53,17 +53,17 @@ func (b *Backtracking) Init(initLoc LinesearchLocation, initStepSize float64, f 
 		panic("backtracking: FunConst must be between 0 and 1")
 	}
 
-	b.stepSize = initStepSize
-	b.initF = initLoc.F
-	b.initG = initLoc.Derivative
+	b.stepSize = step
+	b.initF = loc.F
+	b.initG = loc.Derivative
 	return FunctionEval
 }
 
-func (b *Backtracking) Finished(l LinesearchLocation) bool {
-	return ArmijoConditionMet(l.F, b.initF, b.initG, b.stepSize, b.FunConst)
+func (b *Backtracking) Finished(loc LinesearchLocation) bool {
+	return ArmijoConditionMet(loc.F, b.initF, b.initG, b.stepSize, b.FunConst)
 }
 
-func (b *Backtracking) Iterate(l LinesearchLocation) (float64, EvaluationType, error) {
+func (b *Backtracking) Iterate(_ LinesearchLocation) (float64, EvaluationType, error) {
 	b.stepSize *= b.Decrease
 	if b.stepSize < minimumBacktrackingStepSize {
 		return 0, NoEvaluation, ErrLinesearchFailure

--- a/bisection.go
+++ b/bisection.go
@@ -26,11 +26,11 @@ type Bisection struct {
 	maxGrad  float64
 }
 
-func (b *Bisection) Init(initLoc LinesearchLocation, initStepSize float64, f *FunctionInfo) EvaluationType {
-	if initLoc.Derivative >= 0 {
+func (b *Bisection) Init(loc LinesearchLocation, step float64, _ *FunctionInfo) EvaluationType {
+	if loc.Derivative >= 0 {
 		panic("bisection: init G non-negative")
 	}
-	if initStepSize <= 0 {
+	if step <= 0 {
 		panic("bisection: bad step size")
 	}
 
@@ -43,26 +43,26 @@ func (b *Bisection) Init(initLoc LinesearchLocation, initStepSize float64, f *Fu
 
 	b.minStep = 0
 	b.maxStep = math.Inf(1)
-	b.currStep = initStepSize
+	b.currStep = step
 
-	b.initF = initLoc.F
-	b.minF = initLoc.F
+	b.initF = loc.F
+	b.minF = loc.F
 	b.maxF = math.NaN()
 
-	b.initGrad = initLoc.Derivative
-	b.minGrad = initLoc.Derivative
+	b.initGrad = loc.Derivative
+	b.minGrad = loc.Derivative
 	b.maxGrad = math.NaN()
 
 	return FunctionAndGradientEval
 }
 
-func (b *Bisection) Finished(l LinesearchLocation) bool {
-	return StrongWolfeConditionsMet(l.F, l.Derivative, b.initF, b.initGrad, b.currStep, 0, b.GradConst)
+func (b *Bisection) Finished(loc LinesearchLocation) bool {
+	return StrongWolfeConditionsMet(loc.F, loc.Derivative, b.initF, b.initGrad, b.currStep, 0, b.GradConst)
 }
 
-func (b *Bisection) Iterate(l LinesearchLocation) (float64, EvaluationType, error) {
-	f := l.F
-	g := l.Derivative
+func (b *Bisection) Iterate(loc LinesearchLocation) (float64, EvaluationType, error) {
+	f := loc.F
+	g := loc.Derivative
 	// Deciding on the next step size
 	if math.IsInf(b.maxStep, 1) {
 		// Have not yet bounded the minimum

--- a/gradientdescent.go
+++ b/gradientdescent.go
@@ -18,7 +18,7 @@ type GradientDescent struct {
 	linesearch *Linesearch
 }
 
-func (g *GradientDescent) Init(l *Location, f *FunctionInfo, xNext []float64) (EvaluationType, IterationType, error) {
+func (g *GradientDescent) Init(loc *Location, f *FunctionInfo, xNext []float64) (EvaluationType, IterationType, error) {
 	if g.StepSizer == nil {
 		g.StepSizer = &QuadraticStepSize{}
 	}
@@ -31,21 +31,21 @@ func (g *GradientDescent) Init(l *Location, f *FunctionInfo, xNext []float64) (E
 	g.linesearch.Method = g.LinesearchMethod
 	g.linesearch.NextDirectioner = g
 
-	return g.linesearch.Init(l, f, xNext)
+	return g.linesearch.Init(loc, f, xNext)
 }
 
-func (g *GradientDescent) Iterate(l *Location, xNext []float64) (EvaluationType, IterationType, error) {
-	return g.linesearch.Iterate(l, xNext)
+func (g *GradientDescent) Iterate(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {
+	return g.linesearch.Iterate(loc, xNext)
 }
 
-func (g *GradientDescent) InitDirection(l *Location, direction []float64) (stepSize float64) {
-	copy(direction, l.Gradient)
-	floats.Scale(-1, direction)
-	return g.StepSizer.Init(l, direction)
+func (g *GradientDescent) InitDirection(loc *Location, dir []float64) (stepSize float64) {
+	copy(dir, loc.Gradient)
+	floats.Scale(-1, dir)
+	return g.StepSizer.Init(loc, dir)
 }
 
-func (g *GradientDescent) NextDirection(l *Location, direction []float64) (stepSize float64) {
-	copy(direction, l.Gradient)
-	floats.Scale(-1, direction)
-	return g.StepSizer.StepSize(l, direction)
+func (g *GradientDescent) NextDirection(loc *Location, dir []float64) (stepSize float64) {
+	copy(dir, loc.Gradient)
+	floats.Scale(-1, dir)
+	return g.StepSizer.StepSize(loc, dir)
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -13,13 +13,13 @@ type Function interface {
 // Gradient evaluates the gradient at x and stores the result in place. Df
 // must not modify x.
 type Gradient interface {
-	Df(x []float64, grad []float64)
+	Df(x, grad []float64)
 }
 
 // FunctionGradient evaluates both the derivative and the function at x, storing
 // the gradient in place. FDf must not modify x.
 type FunctionGradient interface {
-	FDf(x []float64, grad []float64) (obj float64)
+	FDf(x, grad []float64) (obj float64)
 }
 
 // LinesearchMethod is a type that can perform a line search. Typically, these
@@ -29,16 +29,16 @@ type LinesearchMethod interface {
 	// Init initializes the linesearch method. LinesearchLocation contains the
 	// function information at step == 0, and step contains the first step length
 	// as specified by the NextDirectioner.
-	Init(init LinesearchLocation, step float64, f *FunctionInfo) EvaluationType
+	Init(loc LinesearchLocation, step float64, f *FunctionInfo) EvaluationType
 
 	// Finished takes in the function result at the most recent linesearch location,
 	// and returns true if the line search has been concluded.
-	Finished(l LinesearchLocation) bool
+	Finished(loc LinesearchLocation) bool
 
 	// Iterate takes in the function results
 	// from evaluating the function at the previous step, and returns the
 	// next step size and EvaluationType to evaluate.
-	Iterate(l LinesearchLocation) (nextStep float64, e EvaluationType, err error)
+	Iterate(loc LinesearchLocation) (step float64, e EvaluationType, err error)
 }
 
 // NextDirectioner implements a strategy for computing a new line search direction
@@ -48,29 +48,29 @@ type NextDirectioner interface {
 	// InitDirection initializes the NextDirectioner at the given starting location,
 	// putting the initial direction in place into dir, and returning the initial
 	// step size. InitDirection must not modify Location.
-	InitDirection(l *Location, dir []float64) (stepSize float64)
+	InitDirection(loc *Location, dir []float64) (step float64)
 
 	// NextDirection updates the search direction and step size. Location is
 	// the location seen at the conclusion of the most recent linesearch. The
-	// next search direction is put in place into dir, and the next stepsize
+	// next search direction is put in place into dir, and the next step size
 	// is returned. NextDirection must not modify Location.
-	NextDirection(l *Location, dir []float64) (stepSize float64)
+	NextDirection(loc *Location, dir []float64) (step float64)
 }
 
 // A Method can optimize an objective function.
 type Method interface {
 	// Initializes the method and returns the first location to evaluate
-	Init(l *Location, f *FunctionInfo, xNext []float64) (EvaluationType, IterationType, error)
+	Init(loc *Location, f *FunctionInfo, xNext []float64) (EvaluationType, IterationType, error)
 
 	// Stores the next location to evaluate in xNext
-	Iterate(l *Location, xNext []float64) (EvaluationType, IterationType, error)
+	Iterate(loc *Location, xNext []float64) (EvaluationType, IterationType, error)
 }
 
 // StepSizer can set the next step size of the optimization given the last Location.
 // Returned step size must be positive.
 type StepSizer interface {
-	Init(l *Location, dir []float64) float64
-	StepSize(l *Location, dir []float64) float64
+	Init(loc *Location, dir []float64) float64
+	StepSize(loc *Location, dir []float64) float64
 }
 
 // Statuser returns the status of the Function being optimized. This can be used

--- a/printer.go
+++ b/printer.go
@@ -55,7 +55,7 @@ func (p *Printer) Init(f *FunctionInfo) error {
 	return nil
 }
 
-func (p *Printer) Record(l *Location, eval EvaluationType, iter IterationType, stats *Stats) error {
+func (p *Printer) Record(loc *Location, _ EvaluationType, iter IterationType, stats *Stats) error {
 	// Only print on major and initial iterations, or if the iteration is over.
 	if iter != MajorIteration && iter != InitIteration && iter != PostIteration {
 		return nil
@@ -72,9 +72,9 @@ func (p *Printer) Record(l *Location, eval EvaluationType, iter IterationType, s
 	var valueStrings [nPrinterOut]string
 	valueStrings[0] = strconv.Itoa(stats.MajorIterations)
 	valueStrings[1] = strconv.Itoa(stats.FunctionEvals + stats.FunctionGradientEvals)
-	valueStrings[2] = fmt.Sprintf("%g", l.F)
+	valueStrings[2] = fmt.Sprintf("%g", loc.F)
 	if p.printGrad {
-		norm := floats.Norm(l.Gradient, math.Inf(1))
+		norm := floats.Norm(loc.Gradient, math.Inf(1))
 		valueStrings[3] = fmt.Sprintf("%g", norm)
 	}
 


### PR DESCRIPTION
* `Location` variables were named `location`, `loc` and `l` at different places in optimize, which was confusing. So this PR unifies `Location` variables to be consistently `loc`.
* `LinesearchLocation` variables are renamed to `loc`, `lsLoc` or `initLoc`, depending on the context. 
* `Linesearch` receiver is renamed to `ls`, `l` seemed too short, especially when `Location`s were still `l` at some places.
* Redundant `[]float64` from `Df()` and `FDf()` are removed.

This PR is simple, but extensive, so it is better reviewed commit by commit.

Remaining inconsistencies:

* `direction` and `dir` (let's use `dir`)
* `initLoc`, `initX`, `currStep` ... vs. `xNext`, `fPrev`, `stepSizePrev`, ... (let's use the abbreviated adjective at the beginning, i.e., `nextX`, `prevF`, ...)