### PR TITLE
Test initial location for NaN or Inf gradient values.

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -13,12 +13,18 @@ var (
 	// ErrInf signifies the initial function value is Inf.
 	ErrInf = errors.New("optimize: initial function value is Inf")
 
+	// ErrGradInf signifies the initial function value is Inf.
+	ErrGradInf = errors.New("optimize: initial gradient is Inf")
+
 	// ErrLinesearchFailure signifies the linesearch has iterated too many
 	// times. This may occur if the gradient tolerance is set too low.
 	ErrLinesearchFailure = errors.New("linesearch: failed to converge")
 
 	// ErrNaN signifies the initial function value is NaN.
 	ErrNaN = errors.New("optimize: initial function value is NaN")
+
+	// ErrGradNaN signifies the initial function value is NaN.
+	ErrGradNaN = errors.New("optimize: initial gradient is NaN")
 
 	// ErrNonNegativeStepDirection signifies that the linesearch has received a
 	// step direction in which the gradient is not negative.

--- a/local.go
+++ b/local.go
@@ -245,6 +245,15 @@ func getStartingLocation(funcs functions, funcInfo *FunctionInfo, initX []float6
 	if math.IsInf(loc.F, 1) {
 		return loc, evalType, ErrInf
 	}
+	for _, v := range loc.Gradient {
+		if math.IsInf(v, 0) {
+			return loc, evalType, ErrGradInf
+		}
+		if math.IsNaN(v) {
+			return loc, evalType, ErrGradNaN
+		}
+	}
+
 	return loc, evalType, nil
 }
 

--- a/unconstrained_test.go
+++ b/unconstrained_test.go
@@ -1136,7 +1136,7 @@ var newtonTests = []UnconstrainedTest{
 		f:      GulfRD{},
 		x:      []float64{5, 2.5, 0.15},
 		optVal: 0,
-		optLoc: []float64{50, 25, 1.5},
+		optLoc: []float64{50.000000001, 24.99999999999, 1.50000000001},
 	},
 	{
 		f:      ExtendedPowell{},
@@ -1506,13 +1506,13 @@ func testMinimize(t *testing.T, tests []UnconstrainedTest, method Method) {
 
 		// TODO: Enable this test once the optimizers reliably handle
 		// minimization from a (nearly) optimal location.
-		// if test.optLoc != nil {
-		// 	settings.UseInitialData = false
-		// 	// Try starting the optimizer from a (nearly) optimum location given by test.optLoc
-		// 	_, err3 := Local(test.f, test.optLoc, settings, method)
-		// 	if err3 != nil {
-		// 		t.Errorf("error finding minimum from a (nearly) optimum location (%v) for:\n%v", err3, test)
-		// 	}
-		// }
+		if test.optLoc != nil {
+			settings.UseInitialData = false
+			// Try starting the optimizer from a (nearly) optimum location given by test.optLoc
+			_, err3 := Local(test.f, test.optLoc, settings, method)
+			if err3 != nil {
+				t.Errorf("error finding minimum from a (nearly) optimum location (%v) for:\n%v", err3, test)
+			}
+		}
 	}
 }


### PR DESCRIPTION
Bad initial gradient values cause the line searches to fail as the Wolfe conditions are never met. Test the initial gradient to make sure it is not NaN or Inf. While here, fix the GulfRD test which has a gradient that evaluates to NaN at the optimum location. This allows the test at the optimum to be re-enabled