### PR TITLE
Don't return NotTerminated from minimize()

### DIFF
--- a/local.go
+++ b/local.go
@@ -145,6 +145,9 @@ func minimize(settings *Settings, method Method, funcInfo *functionInfo, stats *
 		if settings.Recorder != nil {
 			err = settings.Recorder.Record(loc, evalType, iterType, stats)
 			if err != nil {
+				if status == NotTerminated {
+					status = Failure
+				}
 				return
 			}
 		}


### PR DESCRIPTION
This has been discussed before and I think that it is indeed better not to return NotTerminated status, just as you suggested @btracey .