### PR TITLE
Rename function interface

### DIFF
--- a/backtracking.go
+++ b/backtracking.go
@@ -56,7 +56,7 @@ func (b *Backtracking) Init(loc LinesearchLocation, step float64, _ *FunctionInf
 	b.stepSize = step
 	b.initF = loc.F
 	b.initG = loc.Derivative
-	return FunctionEval
+	return FuncEvaluation
 }
 
 func (b *Backtracking) Finished(loc LinesearchLocation) bool {
@@ -68,5 +68,5 @@ func (b *Backtracking) Iterate(_ LinesearchLocation) (float64, EvaluationType, e
 	if b.stepSize < minimumBacktrackingStepSize {
 		return 0, NoEvaluation, ErrLinesearchFailure
 	}
-	return b.stepSize, FunctionEval, nil
+	return b.stepSize, FuncEvaluation, nil
 }

--- a/bisection.go
+++ b/bisection.go
@@ -53,7 +53,7 @@ func (b *Bisection) Init(loc LinesearchLocation, step float64, _ *FunctionInfo) 
 	b.minGrad = loc.Derivative
 	b.maxGrad = math.NaN()
 
-	return FunctionAndGradientEval
+	return FuncGradEvaluation
 }
 
 func (b *Bisection) Finished(loc LinesearchLocation) bool {
@@ -72,7 +72,7 @@ func (b *Bisection) Iterate(loc LinesearchLocation) (float64, EvaluationType, er
 			b.maxStep = b.currStep
 			b.maxF = f
 			b.maxGrad = g
-			return b.checkStepEqual((b.minStep+b.maxStep)/2, FunctionAndGradientEval)
+			return b.checkStepEqual((b.minStep+b.maxStep)/2, FuncGradEvaluation)
 		case f <= b.minF:
 			// Still haven't found an upper bound, but there is not an increase in
 			// function value and the gradient is still negative, so go more in
@@ -80,7 +80,7 @@ func (b *Bisection) Iterate(loc LinesearchLocation) (float64, EvaluationType, er
 			b.minStep = b.currStep
 			b.minF = f
 			b.minGrad = g
-			return b.checkStepEqual(b.currStep*2, FunctionAndGradientEval)
+			return b.checkStepEqual(b.currStep*2, FuncGradEvaluation)
 		default:
 			// Increase in function value, but the gradient is still negative.
 			// Means we must have skipped over a local minimum, so set this point
@@ -88,7 +88,7 @@ func (b *Bisection) Iterate(loc LinesearchLocation) (float64, EvaluationType, er
 			b.maxStep = b.currStep
 			b.maxF = f
 			b.maxGrad = g
-			return b.checkStepEqual((b.minStep+b.maxStep)/2, FunctionAndGradientEval)
+			return b.checkStepEqual((b.minStep+b.maxStep)/2, FuncGradEvaluation)
 		}
 	}
 	// We have already bounded the minimum, so we're just working to find one
@@ -112,7 +112,7 @@ func (b *Bisection) Iterate(loc LinesearchLocation) (float64, EvaluationType, er
 		b.maxF = f
 		b.maxGrad = g
 	}
-	return b.checkStepEqual((b.minStep+b.maxStep)/2, FunctionAndGradientEval)
+	return b.checkStepEqual((b.minStep+b.maxStep)/2, FuncGradEvaluation)
 }
 
 // checkStepEqual checks if the new step is equal to the old step.

--- a/functions/functions.go
+++ b/functions/functions.go
@@ -35,7 +35,7 @@ func (Beale) Func(x []float64) float64 {
 	return f1*f1 + f2*f2 + f3*f3
 }
 
-func (Beale) Df(x, grad []float64) {
+func (Beale) Grad(x, grad []float64) {
 	if len(x) != 2 {
 		panic("dimension of the problem must be 2")
 	}
@@ -89,7 +89,7 @@ func (BiggsEXP2) Func(x []float64) (sum float64) {
 	return sum
 }
 
-func (BiggsEXP2) Df(x, grad []float64) {
+func (BiggsEXP2) Grad(x, grad []float64) {
 	if len(x) != 2 {
 		panic("dimension of the problem must be 2")
 	}
@@ -147,7 +147,7 @@ func (BiggsEXP3) Func(x []float64) (sum float64) {
 	return sum
 }
 
-func (BiggsEXP3) Df(x, grad []float64) {
+func (BiggsEXP3) Grad(x, grad []float64) {
 	if len(x) != 3 {
 		panic("dimension of the problem must be 3")
 	}
@@ -207,7 +207,7 @@ func (BiggsEXP4) Func(x []float64) (sum float64) {
 	return sum
 }
 
-func (BiggsEXP4) Df(x, grad []float64) {
+func (BiggsEXP4) Grad(x, grad []float64) {
 	if len(x) != 4 {
 		panic("dimension of the problem must be 4")
 	}
@@ -269,7 +269,7 @@ func (BiggsEXP5) Func(x []float64) (sum float64) {
 	return sum
 }
 
-func (BiggsEXP5) Df(x, grad []float64) {
+func (BiggsEXP5) Grad(x, grad []float64) {
 	if len(x) != 5 {
 		panic("dimension of the problem must be 5")
 	}
@@ -336,7 +336,7 @@ func (BiggsEXP6) Func(x []float64) (sum float64) {
 	return sum
 }
 
-func (BiggsEXP6) Df(x, grad []float64) {
+func (BiggsEXP6) Grad(x, grad []float64) {
 	if len(x) != 6 {
 		panic("dimension of the problem must be 6")
 	}
@@ -416,7 +416,7 @@ func (Box3D) Func(x []float64) (sum float64) {
 	return sum
 }
 
-func (Box3D) Df(x, grad []float64) {
+func (Box3D) Grad(x, grad []float64) {
 	if len(x) != 3 {
 		panic("dimension of the problem must be 3")
 	}
@@ -479,7 +479,7 @@ func (BrownBadlyScaled) Func(x []float64) float64 {
 	return f1*f1 + f2*f2 + f3*f3
 }
 
-func (BrownBadlyScaled) Df(x, grad []float64) {
+func (BrownBadlyScaled) Grad(x, grad []float64) {
 	if len(x) != 2 {
 		panic("dimension of the problem must be 2")
 	}
@@ -532,7 +532,7 @@ func (BrownAndDennis) Func(x []float64) (sum float64) {
 	return sum
 }
 
-func (BrownAndDennis) Df(x, grad []float64) {
+func (BrownAndDennis) Grad(x, grad []float64) {
 	if len(x) != 4 {
 		panic("dimension of the problem must be 4")
 	}
@@ -596,7 +596,7 @@ func (ExtendedPowellSingular) Func(x []float64) (sum float64) {
 	return sum
 }
 
-func (ExtendedPowellSingular) Df(x, grad []float64) {
+func (ExtendedPowellSingular) Grad(x, grad []float64) {
 	if len(x)%4 != 0 {
 		panic("dimension of the problem must be a multiple of 4")
 	}
@@ -660,7 +660,7 @@ func (ExtendedRosenbrock) Func(x []float64) (sum float64) {
 	return sum
 }
 
-func (ExtendedRosenbrock) Df(x, grad []float64) {
+func (ExtendedRosenbrock) Grad(x, grad []float64) {
 	if len(x) != len(grad) {
 		panic("incorrect size of the gradient")
 	}
@@ -782,7 +782,7 @@ func (g Gaussian) Func(x []float64) (sum float64) {
 	return sum
 }
 
-func (g Gaussian) Df(x, grad []float64) {
+func (g Gaussian) Grad(x, grad []float64) {
 	if len(x) != 3 {
 		panic("dimension of the problem must be 3")
 	}
@@ -844,7 +844,7 @@ func (GulfResearchAndDevelopment) Func(x []float64) (sum float64) {
 	return sum
 }
 
-func (GulfResearchAndDevelopment) Df(x, grad []float64) {
+func (GulfResearchAndDevelopment) Grad(x, grad []float64) {
 	if len(x) != 3 {
 		panic("dimension of the problem must be 3")
 	}
@@ -922,7 +922,7 @@ func (HelicalValley) Func(x []float64) float64 {
 	return f1*f1 + f2*f2 + f3*f3
 }
 
-func (HelicalValley) Df(x, grad []float64) {
+func (HelicalValley) Grad(x, grad []float64) {
 	if len(x) != 3 {
 		panic("dimension of the problem must be 3")
 	}
@@ -963,7 +963,7 @@ func (Linear) Func(x []float64) float64 {
 	return floats.Sum(x)
 }
 
-func (Linear) Df(x, grad []float64) {
+func (Linear) Grad(x, grad []float64) {
 	if len(x) != len(grad) {
 		panic("incorrect size of the gradient")
 	}
@@ -1000,7 +1000,7 @@ func (PenaltyI) Func(x []float64) (sum float64) {
 	return sum
 }
 
-func (PenaltyI) Df(x, grad []float64) {
+func (PenaltyI) Grad(x, grad []float64) {
 	if len(x) != len(grad) {
 		panic("incorrect size of the gradient")
 	}
@@ -1065,7 +1065,7 @@ func (PenaltyII) Func(x []float64) (sum float64) {
 	return sum
 }
 
-func (PenaltyII) Df(x, grad []float64) {
+func (PenaltyII) Grad(x, grad []float64) {
 	if len(x) != len(grad) {
 		panic("incorrect size of the gradient")
 	}
@@ -1134,7 +1134,7 @@ func (PowellBadlyScaled) Func(x []float64) float64 {
 	return f1*f1 + f2*f2
 }
 
-func (PowellBadlyScaled) Df(x, grad []float64) {
+func (PowellBadlyScaled) Grad(x, grad []float64) {
 	if len(x) != 2 {
 		panic("dimension of the problem must be 2")
 	}
@@ -1183,7 +1183,7 @@ func (Trigonometric) Func(x []float64) (sum float64) {
 	return sum
 }
 
-func (Trigonometric) Df(x, grad []float64) {
+func (Trigonometric) Grad(x, grad []float64) {
 	if len(x) != len(grad) {
 		panic("incorrect size of the gradient")
 	}
@@ -1255,7 +1255,7 @@ func (VariablyDimensioned) Func(x []float64) (sum float64) {
 	return sum
 }
 
-func (VariablyDimensioned) Df(x, grad []float64) {
+func (VariablyDimensioned) Grad(x, grad []float64) {
 	if len(x) != len(grad) {
 		panic("incorrect size of the gradient")
 	}
@@ -1339,7 +1339,7 @@ func (Watson) Func(x []float64) (sum float64) {
 	return sum
 }
 
-func (Watson) Df(x, grad []float64) {
+func (Watson) Grad(x, grad []float64) {
 	if len(x) != len(grad) {
 		panic("incorrect size of the gradient")
 	}
@@ -1430,7 +1430,7 @@ func (Wood) Func(x []float64) (sum float64) {
 	return 100*f1*f1 + f2*f2 + 90*f3*f3 + f4*f4 + 10*f5*f5 + 0.1*f6*f6
 }
 
-func (Wood) Df(x, grad []float64) {
+func (Wood) Grad(x, grad []float64) {
 	if len(x) != 4 {
 		panic("dimension of the problem must be 4")
 	}

--- a/functions/functions.go
+++ b/functions/functions.go
@@ -24,7 +24,7 @@ import (
 //    optimization software. ACM Trans Math Softw 7 (1981), 17-41
 type Beale struct{}
 
-func (Beale) F(x []float64) float64 {
+func (Beale) Func(x []float64) float64 {
 	if len(x) != 2 {
 		panic("dimension of the problem must be 2")
 	}
@@ -75,7 +75,7 @@ func (Beale) Minima() []Minimum {
 //  of the objective function. IMA J Appl Math 8 (1971), 315-327; doi:10.1093/imamat/8.3.315
 type BiggsEXP2 struct{}
 
-func (BiggsEXP2) F(x []float64) (sum float64) {
+func (BiggsEXP2) Func(x []float64) (sum float64) {
 	if len(x) != 2 {
 		panic("dimension of the problem must be 2")
 	}
@@ -133,7 +133,7 @@ func (BiggsEXP2) Minima() []Minimum {
 //  of the objective function. IMA J Appl Math 8 (1971), 315-327; doi:10.1093/imamat/8.3.315
 type BiggsEXP3 struct{}
 
-func (BiggsEXP3) F(x []float64) (sum float64) {
+func (BiggsEXP3) Func(x []float64) (sum float64) {
 	if len(x) != 3 {
 		panic("dimension of the problem must be 3")
 	}
@@ -193,7 +193,7 @@ func (BiggsEXP3) Minima() []Minimum {
 //  of the objective function. IMA J Appl Math 8 (1971), 315-327; doi:10.1093/imamat/8.3.315
 type BiggsEXP4 struct{}
 
-func (BiggsEXP4) F(x []float64) (sum float64) {
+func (BiggsEXP4) Func(x []float64) (sum float64) {
 	if len(x) != 4 {
 		panic("dimension of the problem must be 4")
 	}
@@ -255,7 +255,7 @@ func (BiggsEXP4) Minima() []Minimum {
 //  of the objective function. IMA J Appl Math 8 (1971), 315-327; doi:10.1093/imamat/8.3.315
 type BiggsEXP5 struct{}
 
-func (BiggsEXP5) F(x []float64) (sum float64) {
+func (BiggsEXP5) Func(x []float64) (sum float64) {
 	if len(x) != 5 {
 		panic("dimension of the problem must be 5")
 	}
@@ -322,7 +322,7 @@ func (BiggsEXP5) Minima() []Minimum {
 //    optimization software. ACM Trans Math Softw 7 (1981), 17-41
 type BiggsEXP6 struct{}
 
-func (BiggsEXP6) F(x []float64) (sum float64) {
+func (BiggsEXP6) Func(x []float64) (sum float64) {
 	if len(x) != 6 {
 		panic("dimension of the problem must be 6")
 	}
@@ -402,7 +402,7 @@ func (BiggsEXP6) Minima() []Minimum {
 //    optimization software. ACM Trans Math Softw 7 (1981), 17-41
 type Box3D struct{}
 
-func (Box3D) F(x []float64) (sum float64) {
+func (Box3D) Func(x []float64) (sum float64) {
 	if len(x) != 3 {
 		panic("dimension of the problem must be 3")
 	}
@@ -468,7 +468,7 @@ func (Box3D) Minima() []Minimum {
 //    optimization software. ACM Trans Math Softw 7 (1981), 17-41
 type BrownBadlyScaled struct{}
 
-func (BrownBadlyScaled) F(x []float64) float64 {
+func (BrownBadlyScaled) Func(x []float64) float64 {
 	if len(x) != 2 {
 		panic("dimension of the problem must be 2")
 	}
@@ -517,7 +517,7 @@ func (BrownBadlyScaled) Minima() []Minimum {
 //    optimization software. ACM Trans Math Softw 7 (1981), 17-41
 type BrownAndDennis struct{}
 
-func (BrownAndDennis) F(x []float64) (sum float64) {
+func (BrownAndDennis) Func(x []float64) (sum float64) {
 	if len(x) != 4 {
 		panic("dimension of the problem must be 4")
 	}
@@ -579,7 +579,7 @@ func (BrownAndDennis) Minima() []Minimum {
 //    optimization software. ACM Trans Math Softw 7 (1981), 17-41
 type ExtendedPowellSingular struct{}
 
-func (ExtendedPowellSingular) F(x []float64) (sum float64) {
+func (ExtendedPowellSingular) Func(x []float64) (sum float64) {
 	if len(x)%4 != 0 {
 		panic("dimension of the problem must be a multiple of 4")
 	}
@@ -651,7 +651,7 @@ func (ExtendedPowellSingular) Minima() []Minimum {
 //  - http://en.wikipedia.org/wiki/Rosenbrock_function
 type ExtendedRosenbrock struct{}
 
-func (ExtendedRosenbrock) F(x []float64) (sum float64) {
+func (ExtendedRosenbrock) Func(x []float64) (sum float64) {
 	for i := 0; i < len(x)-1; i++ {
 		a := 1 - x[i]
 		b := x[i+1] - x[i]*x[i]
@@ -766,7 +766,7 @@ func (Gaussian) y(i int) (yi float64) {
 	return yi
 }
 
-func (g Gaussian) F(x []float64) (sum float64) {
+func (g Gaussian) Func(x []float64) (sum float64) {
 	if len(x) != 3 {
 		panic("dimension of the problem must be 3")
 	}
@@ -828,7 +828,7 @@ func (Gaussian) Minima() []Minimum {
 //    optimization software. ACM Trans Math Softw 7 (1981), 17-41
 type GulfResearchAndDevelopment struct{}
 
-func (GulfResearchAndDevelopment) F(x []float64) (sum float64) {
+func (GulfResearchAndDevelopment) Func(x []float64) (sum float64) {
 	if len(x) != 3 {
 		panic("dimension of the problem must be 3")
 	}
@@ -904,7 +904,7 @@ func (GulfResearchAndDevelopment) Minima() []Minimum {
 //    optimization software. ACM Trans Math Softw 7 (1981), 17-41
 type HelicalValley struct{}
 
-func (HelicalValley) F(x []float64) float64 {
+func (HelicalValley) Func(x []float64) float64 {
 	if len(x) != 3 {
 		panic("dimension of the problem must be 3")
 	}
@@ -959,7 +959,7 @@ func (HelicalValley) Minima() []Minimum {
 // Linear implements a linear function.
 type Linear struct{}
 
-func (Linear) F(x []float64) float64 {
+func (Linear) Func(x []float64) float64 {
 	return floats.Sum(x)
 }
 
@@ -986,7 +986,7 @@ func (Linear) Df(x, grad []float64) {
 //    optimization software. ACM Trans Math Softw 7 (1981), 17-41
 type PenaltyI struct{}
 
-func (PenaltyI) F(x []float64) (sum float64) {
+func (PenaltyI) Func(x []float64) (sum float64) {
 	for _, v := range x {
 		sum += (v - 1) * (v - 1)
 	}
@@ -1044,7 +1044,7 @@ func (PenaltyI) Minima() []Minimum {
 //    optimization software. ACM Trans Math Softw 7 (1981), 17-41
 type PenaltyII struct{}
 
-func (PenaltyII) F(x []float64) (sum float64) {
+func (PenaltyII) Func(x []float64) (sum float64) {
 	dim := len(x)
 	s := -1.0
 	for i, v := range x {
@@ -1124,7 +1124,7 @@ func (PenaltyII) Minima() []Minimum {
 //    optimization software. ACM Trans Math Softw 7 (1981), 17-41
 type PowellBadlyScaled struct{}
 
-func (PowellBadlyScaled) F(x []float64) float64 {
+func (PowellBadlyScaled) Func(x []float64) float64 {
 	if len(x) != 2 {
 		panic("dimension of the problem must be 2")
 	}
@@ -1171,7 +1171,7 @@ func (PowellBadlyScaled) Minima() []Minimum {
 //    optimization software. ACM Trans Math Softw 7 (1981), 17-41
 type Trigonometric struct{}
 
-func (Trigonometric) F(x []float64) (sum float64) {
+func (Trigonometric) Func(x []float64) (sum float64) {
 	var s1 float64
 	for _, v := range x {
 		s1 += math.Cos(v)
@@ -1238,7 +1238,7 @@ func (Trigonometric) Minima() []Minimum {
 //  software. ACM Trans Math Softw 7 (1981), 17-41
 type VariablyDimensioned struct{}
 
-func (VariablyDimensioned) F(x []float64) (sum float64) {
+func (VariablyDimensioned) Func(x []float64) (sum float64) {
 	for _, v := range x {
 		t := v - 1
 		sum += t * t
@@ -1313,7 +1313,7 @@ func (VariablyDimensioned) Minima() []Minimum {
 //    optimization software. ACM Trans Math Softw 7 (1981), 17-41
 type Watson struct{}
 
-func (Watson) F(x []float64) (sum float64) {
+func (Watson) Func(x []float64) (sum float64) {
 	for i := 1; i <= 29; i++ {
 		d1 := float64(i) / 29
 
@@ -1416,7 +1416,7 @@ func (Watson) Minima() []Minimum {
 //    optimization software. ACM Trans Math Softw 7 (1981), 17-41
 type Wood struct{}
 
-func (Wood) F(x []float64) (sum float64) {
+func (Wood) Func(x []float64) (sum float64) {
 	if len(x) != 4 {
 		panic("dimension of the problem must be 4")
 	}

--- a/functions/minsurf.go
+++ b/functions/minsurf.go
@@ -45,8 +45,8 @@ func NewMinimalSurface(nx, ny int) *MinimalSurface {
 	return ms
 }
 
-// F returns the area of the surface represented by the vector x.
-func (ms *MinimalSurface) F(x []float64) (area float64) {
+// Func returns the area of the surface represented by the vector x.
+func (ms *MinimalSurface) Func(x []float64) (area float64) {
 	return ms.FDf(x, nil)
 }
 

--- a/functions/minsurf.go
+++ b/functions/minsurf.go
@@ -47,12 +47,12 @@ func NewMinimalSurface(nx, ny int) *MinimalSurface {
 
 // Func returns the area of the surface represented by the vector x.
 func (ms *MinimalSurface) Func(x []float64) (area float64) {
-	return ms.FDf(x, nil)
+	return ms.FuncGrad(x, nil)
 }
 
-// FDf returns the area of the surface represented by the vector x and
+// FuncGrad returns the area of the surface represented by the vector x and
 // evaluates its gradient.
-func (ms *MinimalSurface) FDf(x, grad []float64) (area float64) {
+func (ms *MinimalSurface) FuncGrad(x, grad []float64) (area float64) {
 	nx, ny := ms.Dims()
 	if len(x) != (nx-2)*(ny-2) {
 		panic("problem size mismatch")

--- a/functions/minsurf_test.go
+++ b/functions/minsurf_test.go
@@ -22,7 +22,7 @@ func TestMinimalSurface(t *testing.T) {
 		x0 := f.InitX()
 		grad := make([]float64, len(x0))
 		f.FDf(x0, grad)
-		fdGrad := fd.Gradient(nil, f.F, x0, nil)
+		fdGrad := fd.Gradient(nil, f.Func, x0, nil)
 
 		// Test that the numerical and analytical gradients agree.
 		dist := floats.Distance(grad, fdGrad, math.Inf(1))

--- a/functions/minsurf_test.go
+++ b/functions/minsurf_test.go
@@ -21,7 +21,7 @@ func TestMinimalSurface(t *testing.T) {
 		f := NewMinimalSurface(size[0], size[1])
 		x0 := f.InitX()
 		grad := make([]float64, len(x0))
-		f.FDf(x0, grad)
+		f.FuncGrad(x0, grad)
 		fdGrad := fd.Gradient(nil, f.Func, x0, nil)
 
 		// Test that the numerical and analytical gradients agree.
@@ -38,7 +38,7 @@ func TestMinimalSurface(t *testing.T) {
 		// solving. This is the reason why a relatively loose tolerance 1e-4
 		// must be used.
 		xSol := f.ExactX()
-		f.FDf(xSol, grad)
+		f.FuncGrad(xSol, grad)
 		norm := floats.Norm(grad, math.Inf(1))
 		if norm > 1e-4 {
 			t.Errorf("grid %v x %v: gradient at the minimum not small enough. |grad|_∞ = %v",

--- a/functions/validate.go
+++ b/functions/validate.go
@@ -28,7 +28,7 @@ type gradient interface {
 }
 
 type functionGradient interface {
-	FDf(x, grad []float64) float64
+	FuncGrad(x, grad []float64) float64
 }
 
 // minimumer is an objective function that can also provide information about
@@ -139,16 +139,16 @@ func testFunction(f function, ftests []funcTest, t *testing.T) {
 		// value and the gradient correctly.
 		if isFunctionGradient {
 			grad := make([]float64, len(test.Gradient))
-			F := fFunctionGradient.FDf(test.X, grad)
+			F := fFunctionGradient.FuncGrad(test.X, grad)
 
 			if math.Abs(F-test.F) > defaultTol {
-				t.Errorf("Test #%d: function value given by FDf() is incorrect. Want: %v, Got: %v",
+				t.Errorf("Test #%d: function value given by FuncGrad() is incorrect. Want: %v, Got: %v",
 					i, test.F, F)
 			}
 
 			if !floats.EqualApprox(grad, test.Gradient, defaultGradTol) {
 				dist := floats.Distance(grad, test.Gradient, math.Inf(1))
-				t.Errorf("Test #%d: gradient given by FDf() is incorrect. |grad - WantGrad|_∞ = %v",
+				t.Errorf("Test #%d: gradient given by FuncGrad() is incorrect. |grad - WantGrad|_∞ = %v",
 					i, dist)
 			}
 		}

--- a/functions/validate.go
+++ b/functions/validate.go
@@ -20,7 +20,7 @@ import (
 
 // function represents an objective function.
 type function interface {
-	F(x []float64) float64
+	Func(x []float64) float64
 }
 
 type gradient interface {
@@ -101,11 +101,11 @@ func testFunction(f function, ftests []funcTest, t *testing.T) {
 	}
 
 	for i, test := range tests {
-		F := f.F(test.X)
+		F := f.Func(test.X)
 
 		// Check that the function value is as expected.
 		if math.Abs(F-test.F) > defaultTol {
-			t.Errorf("Test #%d: function value given by F() is incorrect. Want: %v, Got: %v",
+			t.Errorf("Test #%d: function value given by Func() is incorrect. Want: %v, Got: %v",
 				i, test.F, F)
 		}
 
@@ -114,7 +114,7 @@ func testFunction(f function, ftests []funcTest, t *testing.T) {
 		}
 
 		// Evaluate the finite difference gradient.
-		fdGrad := fd.Gradient(nil, f.F, test.X, nil)
+		fdGrad := fd.Gradient(nil, f.Func, test.X, nil)
 
 		// Check that the finite difference and expected gradients match.
 		if !floats.EqualApprox(fdGrad, test.Gradient, defaultFDGradTol) {

--- a/functions/validate.go
+++ b/functions/validate.go
@@ -24,7 +24,7 @@ type function interface {
 }
 
 type gradient interface {
-	Df(x, grad []float64)
+	Grad(x, grad []float64)
 }
 
 type functionGradient interface {
@@ -126,11 +126,11 @@ func testFunction(f function, ftests []funcTest, t *testing.T) {
 		// If the function is a Gradient, check that it computes the gradient correctly.
 		if isGradient {
 			grad := make([]float64, len(test.Gradient))
-			fGradient.Df(test.X, grad)
+			fGradient.Grad(test.X, grad)
 
 			if !floats.EqualApprox(grad, test.Gradient, defaultGradTol) {
 				dist := floats.Distance(grad, test.Gradient, math.Inf(1))
-				t.Errorf("Test #%d: gradient given by Df() is incorrect. |grad - WantGrad|_∞ = %v",
+				t.Errorf("Test #%d: gradient given by Grad() is incorrect. |grad - WantGrad|_∞ = %v",
 					i, dist)
 			}
 		}

--- a/interfaces.go
+++ b/interfaces.go
@@ -7,7 +7,7 @@ package optimize
 // Function evaluates the objective function at the given location. F
 // must not modify x.
 type Function interface {
-	F(x []float64) (obj float64)
+	Func(x []float64) (obj float64)
 }
 
 // Gradient evaluates the gradient at x and stores the result in place. Df

--- a/interfaces.go
+++ b/interfaces.go
@@ -10,10 +10,10 @@ type Function interface {
 	Func(x []float64) (obj float64)
 }
 
-// Gradient evaluates the gradient at x and stores the result in place. Df
-// must not modify x.
+// Gradient evaluates the gradient at x and stores the result in-place in grad.
+// Grad must not modify x.
 type Gradient interface {
-	Df(x, grad []float64)
+	Grad(x, grad []float64)
 }
 
 // FunctionGradient evaluates both the derivative and the function at x, storing

--- a/interfaces.go
+++ b/interfaces.go
@@ -16,10 +16,10 @@ type Gradient interface {
 	Grad(x, grad []float64)
 }
 
-// FunctionGradient evaluates both the derivative and the function at x, storing
-// the gradient in place. FDf must not modify x.
+// FunctionGradient evaluates both the function and the gradient at x, storing
+// the gradient in-place in grad. FuncGrad must not modify x.
 type FunctionGradient interface {
-	FDf(x, grad []float64) (obj float64)
+	FuncGrad(x, grad []float64) (obj float64)
 }
 
 // LinesearchMethod is a type that can perform a line search. Typically, these

--- a/linesearch.go
+++ b/linesearch.go
@@ -81,7 +81,7 @@ func (ls *Linesearch) Iterate(loc *Location, xNext []float64) (EvaluationType, I
 			// have the gradient, so get it before announcing MajorIteration.
 			ls.iterType = SubIteration
 			copy(xNext, loc.X)
-			return GradientEval, ls.iterType, nil
+			return GradEvaluation, ls.iterType, nil
 		}
 		// The linesearch is finished. Announce so with an update to
 		// MajorIteration. The function value and gradient is already known, so

--- a/linesearch.go
+++ b/linesearch.go
@@ -76,7 +76,7 @@ func (ls *Linesearch) Iterate(loc *Location, xNext []float64) (EvaluationType, I
 		Derivative: projGrad,
 	}
 	if ls.Method.Finished(lsLoc) {
-		if ls.lastEvalType == FunctionEval && loc.Gradient != nil {
+		if ls.lastEvalType == FuncEvaluation && loc.Gradient != nil {
 			// We have the function value at the current location, but we don't
 			// have the gradient, so get it before announcing MajorIteration.
 			ls.iterType = SubIteration

--- a/local.go
+++ b/local.go
@@ -318,7 +318,7 @@ func evaluate(funcInfo *functionInfo, evalType EvaluationType, xNext []float64, 
 				loc.Gradient[i] = math.NaN()
 			}
 		}
-		loc.F = funcInfo.function.F(loc.X)
+		loc.F = funcInfo.function.Func(loc.X)
 		stats.FunctionEvals++
 		return
 	case GradientEval:
@@ -344,7 +344,7 @@ func evaluate(funcInfo *functionInfo, evalType EvaluationType, xNext []float64, 
 			return
 		}
 		if funcInfo.IsGradient {
-			loc.F = funcInfo.function.F(loc.X)
+			loc.F = funcInfo.function.Func(loc.X)
 			stats.FunctionEvals++
 			funcInfo.gradient.Df(loc.X, loc.Gradient)
 			stats.GradientEvals++

--- a/local.go
+++ b/local.go
@@ -328,7 +328,7 @@ func evaluate(funcInfo *functionInfo, evalType EvaluationType, xNext []float64, 
 				// evaluated.
 				loc.F = math.NaN()
 			}
-			funcInfo.gradient.Df(loc.X, loc.Gradient)
+			funcInfo.gradient.Grad(loc.X, loc.Gradient)
 			stats.GradientEvals++
 			return
 		}
@@ -346,7 +346,7 @@ func evaluate(funcInfo *functionInfo, evalType EvaluationType, xNext []float64, 
 		if funcInfo.IsGradient {
 			loc.F = funcInfo.function.Func(loc.X)
 			stats.FunctionEvals++
-			funcInfo.gradient.Df(loc.X, loc.Gradient)
+			funcInfo.gradient.Grad(loc.X, loc.Gradient)
 			stats.GradientEvals++
 			return
 		}

--- a/local.go
+++ b/local.go
@@ -279,9 +279,9 @@ func checkConvergence(loc *Location, iterType IterationType, stats *Stats, setti
 		}
 	}
 
-	if settings.GradientEvals > 0 {
-		totalGrad := stats.GradientEvals + stats.FunctionGradientEvals
-		if totalGrad >= settings.GradientEvals {
+	if settings.GradEvaluations > 0 {
+		totalGrad := stats.GradEvaluations + stats.FunctionGradientEvals
+		if totalGrad >= settings.GradEvaluations {
 			return GradientEvaluationLimit
 		}
 	}
@@ -329,7 +329,7 @@ func evaluate(funcInfo *functionInfo, evalType EvaluationType, xNext []float64, 
 				loc.F = math.NaN()
 			}
 			funcInfo.gradient.Grad(loc.X, loc.Gradient)
-			stats.GradientEvals++
+			stats.GradEvaluations++
 			return
 		}
 		if funcInfo.IsFunctionGradient {
@@ -347,7 +347,7 @@ func evaluate(funcInfo *functionInfo, evalType EvaluationType, xNext []float64, 
 			loc.F = funcInfo.function.Func(loc.X)
 			stats.FuncEvaluations++
 			funcInfo.gradient.Grad(loc.X, loc.Gradient)
-			stats.GradientEvals++
+			stats.GradEvaluations++
 			return
 		}
 	case NoEvaluation:

--- a/local.go
+++ b/local.go
@@ -273,14 +273,14 @@ func checkConvergence(loc *Location, iterType IterationType, stats *Stats, setti
 	}
 
 	if settings.FuncEvaluations > 0 {
-		totalFun := stats.FuncEvaluations + stats.FunctionGradientEvals
+		totalFun := stats.FuncEvaluations + stats.FuncGradEvaluations
 		if totalFun >= settings.FuncEvaluations {
 			return FunctionEvaluationLimit
 		}
 	}
 
 	if settings.GradEvaluations > 0 {
-		totalGrad := stats.GradEvaluations + stats.FunctionGradientEvals
+		totalGrad := stats.GradEvaluations + stats.FuncGradEvaluations
 		if totalGrad >= settings.GradEvaluations {
 			return GradientEvaluationLimit
 		}
@@ -334,13 +334,13 @@ func evaluate(funcInfo *functionInfo, evalType EvaluationType, xNext []float64, 
 		}
 		if funcInfo.IsFunctionGradient {
 			loc.F = funcInfo.functionGradient.FuncGrad(loc.X, loc.Gradient)
-			stats.FunctionGradientEvals++
+			stats.FuncGradEvaluations++
 			return
 		}
 	case FuncGradEvaluation:
 		if funcInfo.IsFunctionGradient {
 			loc.F = funcInfo.functionGradient.FuncGrad(loc.X, loc.Gradient)
-			stats.FunctionGradientEvals++
+			stats.FuncGradEvaluations++
 			return
 		}
 		if funcInfo.IsGradient {

--- a/local.go
+++ b/local.go
@@ -230,7 +230,7 @@ func getStartingLocation(funcInfo *functionInfo, initX []float64, stats *Stats, 
 	} else {
 		evalType = FuncEvaluation
 		if loc.Gradient != nil {
-			evalType = FunctionAndGradientEval
+			evalType = FuncGradEvaluation
 		}
 		evaluate(funcInfo, evalType, loc.X, loc, stats)
 	}
@@ -337,7 +337,7 @@ func evaluate(funcInfo *functionInfo, evalType EvaluationType, xNext []float64, 
 			stats.FunctionGradientEvals++
 			return
 		}
-	case FunctionAndGradientEval:
+	case FuncGradEvaluation:
 		if funcInfo.IsFunctionGradient {
 			loc.F = funcInfo.functionGradient.FuncGrad(loc.X, loc.Gradient)
 			stats.FunctionGradientEvals++

--- a/local.go
+++ b/local.go
@@ -321,7 +321,7 @@ func evaluate(funcInfo *functionInfo, evalType EvaluationType, xNext []float64, 
 		loc.F = funcInfo.function.Func(loc.X)
 		stats.FunctionEvals++
 		return
-	case GradientEval:
+	case GradEvaluation:
 		if funcInfo.IsGradient {
 			if different {
 				// Invalidate the function value because it will not be

--- a/local.go
+++ b/local.go
@@ -272,9 +272,9 @@ func checkConvergence(loc *Location, iterType IterationType, stats *Stats, setti
 		return FunctionNegativeInfinity
 	}
 
-	if settings.FunctionEvals > 0 {
-		totalFun := stats.FunctionEvals + stats.FunctionGradientEvals
-		if totalFun >= settings.FunctionEvals {
+	if settings.FuncEvaluations > 0 {
+		totalFun := stats.FuncEvaluations + stats.FunctionGradientEvals
+		if totalFun >= settings.FuncEvaluations {
 			return FunctionEvaluationLimit
 		}
 	}
@@ -319,7 +319,7 @@ func evaluate(funcInfo *functionInfo, evalType EvaluationType, xNext []float64, 
 			}
 		}
 		loc.F = funcInfo.function.Func(loc.X)
-		stats.FunctionEvals++
+		stats.FuncEvaluations++
 		return
 	case GradEvaluation:
 		if funcInfo.IsGradient {
@@ -345,7 +345,7 @@ func evaluate(funcInfo *functionInfo, evalType EvaluationType, xNext []float64, 
 		}
 		if funcInfo.IsGradient {
 			loc.F = funcInfo.function.Func(loc.X)
-			stats.FunctionEvals++
+			stats.FuncEvaluations++
 			funcInfo.gradient.Grad(loc.X, loc.Gradient)
 			stats.GradientEvals++
 			return

--- a/local.go
+++ b/local.go
@@ -333,13 +333,13 @@ func evaluate(funcInfo *functionInfo, evalType EvaluationType, xNext []float64, 
 			return
 		}
 		if funcInfo.IsFunctionGradient {
-			loc.F = funcInfo.functionGradient.FDf(loc.X, loc.Gradient)
+			loc.F = funcInfo.functionGradient.FuncGrad(loc.X, loc.Gradient)
 			stats.FunctionGradientEvals++
 			return
 		}
 	case FunctionAndGradientEval:
 		if funcInfo.IsFunctionGradient {
-			loc.F = funcInfo.functionGradient.FDf(loc.X, loc.Gradient)
+			loc.F = funcInfo.functionGradient.FuncGrad(loc.X, loc.Gradient)
 			stats.FunctionGradientEvals++
 			return
 		}

--- a/local.go
+++ b/local.go
@@ -228,7 +228,7 @@ func getStartingLocation(funcInfo *functionInfo, initX []float64, stats *Stats, 
 			copy(loc.Gradient, initG)
 		}
 	} else {
-		evalType = FunctionEval
+		evalType = FuncEvaluation
 		if loc.Gradient != nil {
 			evalType = FunctionAndGradientEval
 		}
@@ -311,7 +311,7 @@ func evaluate(funcInfo *functionInfo, evalType EvaluationType, xNext []float64, 
 		copy(loc.X, xNext)
 	}
 	switch evalType {
-	case FunctionEval:
+	case FuncEvaluation:
 		if different {
 			// Invalidate the gradient because it will not be evaluated.
 			for i := range loc.Gradient {

--- a/printer.go
+++ b/printer.go
@@ -71,7 +71,7 @@ func (p *Printer) Record(loc *Location, _ EvaluationType, iter IterationType, st
 	// Make the value strings
 	var valueStrings [nPrinterOut]string
 	valueStrings[0] = strconv.Itoa(stats.MajorIterations)
-	valueStrings[1] = strconv.Itoa(stats.FuncEvaluations + stats.FunctionGradientEvals)
+	valueStrings[1] = strconv.Itoa(stats.FuncEvaluations + stats.FuncGradEvaluations)
 	valueStrings[2] = fmt.Sprintf("%g", loc.F)
 	if p.printGrad {
 		norm := floats.Norm(loc.Gradient, math.Inf(1))

--- a/printer.go
+++ b/printer.go
@@ -71,7 +71,7 @@ func (p *Printer) Record(loc *Location, _ EvaluationType, iter IterationType, st
 	// Make the value strings
 	var valueStrings [nPrinterOut]string
 	valueStrings[0] = strconv.Itoa(stats.MajorIterations)
-	valueStrings[1] = strconv.Itoa(stats.FunctionEvals + stats.FunctionGradientEvals)
+	valueStrings[1] = strconv.Itoa(stats.FuncEvaluations + stats.FunctionGradientEvals)
 	valueStrings[2] = fmt.Sprintf("%g", loc.F)
 	if p.printGrad {
 		norm := floats.Norm(loc.Gradient, math.Inf(1))

--- a/types.go
+++ b/types.go
@@ -92,7 +92,7 @@ type Stats struct {
 	MajorIterations       int           // Total number of major iterations
 	FunctionEvals         int           // Number of evaluations of Func()
 	GradientEvals         int           // Number of evaluations of Grad()
-	FunctionGradientEvals int           // Number of evaluations of FDf()
+	FunctionGradientEvals int           // Number of evaluations of FuncGrad()
 	Runtime               time.Duration // Total runtime of the optimization
 }
 
@@ -158,7 +158,7 @@ type Settings struct {
 	// FunctionEvals is the maximum allowed number of function evaluations.
 	// FunctionEvaluationLimit status is returned  if the total number of
 	// function evaluations equals or exceeds this number. Calls to Func() and
-	// FDf() are both counted as function evaluations for this calculation.
+	// FuncGrad() are both counted as function evaluations for this calculation.
 	// If it equals zero, this setting has no effect.
 	// The default value is 0.
 	FunctionEvals int
@@ -166,7 +166,7 @@ type Settings struct {
 	// GradientEvals is the maximum allowed number of gradient evaluations.
 	// GradientEvaluationLimit status is returned if the total number of
 	// gradient evaluations equals or exceeds this number. Calls to Grad() and
-	// FDf() are both counted as gradient evaluations for this calculation.
+	// FuncGrad() are both counted as gradient evaluations for this calculation.
 	// If it equals zero, this setting has no effect.
 	// The default value is 0.
 	GradientEvals int

--- a/types.go
+++ b/types.go
@@ -90,7 +90,7 @@ type Result struct {
 // Stats contains the statistics of the run.
 type Stats struct {
 	MajorIterations       int           // Total number of major iterations
-	FunctionEvals         int           // Number of evaluations of Func()
+	FuncEvaluations       int           // Number of evaluations of Func()
 	GradientEvals         int           // Number of evaluations of Grad()
 	FunctionGradientEvals int           // Number of evaluations of FuncGrad()
 	Runtime               time.Duration // Total runtime of the optimization
@@ -155,13 +155,13 @@ type Settings struct {
 	// The default value is 0.
 	Runtime time.Duration
 
-	// FunctionEvals is the maximum allowed number of function evaluations.
-	// FunctionEvaluationLimit status is returned  if the total number of
+	// FuncEvaluations is the maximum allowed number of function evaluations.
+	// FunctionEvaluationLimit status is returned if the total number of
 	// function evaluations equals or exceeds this number. Calls to Func() and
 	// FuncGrad() are both counted as function evaluations for this calculation.
 	// If it equals zero, this setting has no effect.
 	// The default value is 0.
-	FunctionEvals int
+	FuncEvaluations int
 
 	// GradientEvals is the maximum allowed number of gradient evaluations.
 	// GradientEvaluationLimit status is returned if the total number of

--- a/types.go
+++ b/types.go
@@ -91,7 +91,7 @@ type Result struct {
 type Stats struct {
 	MajorIterations       int           // Total number of major iterations
 	FunctionEvals         int           // Number of evaluations of Func()
-	GradientEvals         int           // Number of evaluations of Df()
+	GradientEvals         int           // Number of evaluations of Grad()
 	FunctionGradientEvals int           // Number of evaluations of FDf()
 	Runtime               time.Duration // Total runtime of the optimization
 }
@@ -126,7 +126,7 @@ type functionInfo struct {
 type Settings struct {
 	UseInitialData       bool      // Use supplied information about the conditions at the initial x.
 	InitialFunctionValue float64   // Func(x) at the initial x.
-	InitialGradient      []float64 // Df(x) at the initial x.
+	InitialGradient      []float64 // Grad(x) at the initial x.
 
 	// FunctionAbsTol is the threshold for acceptably small values of the
 	// objective function. FunctionAbsoluteConvergence status is returned if
@@ -165,7 +165,7 @@ type Settings struct {
 
 	// GradientEvals is the maximum allowed number of gradient evaluations.
 	// GradientEvaluationLimit status is returned if the total number of
-	// gradient evaluations equals or exceeds this number. Calls to Df() and
+	// gradient evaluations equals or exceeds this number. Calls to Grad() and
 	// FDf() are both counted as gradient evaluations for this calculation.
 	// If it equals zero, this setting has no effect.
 	// The default value is 0.

--- a/types.go
+++ b/types.go
@@ -90,7 +90,7 @@ type Result struct {
 // Stats contains the statistics of the run.
 type Stats struct {
 	MajorIterations       int           // Total number of major iterations
-	FunctionEvals         int           // Number of evaluations of F()
+	FunctionEvals         int           // Number of evaluations of Func()
 	GradientEvals         int           // Number of evaluations of Df()
 	FunctionGradientEvals int           // Number of evaluations of FDf()
 	Runtime               time.Duration // Total runtime of the optimization
@@ -125,7 +125,7 @@ type functionInfo struct {
 // If Recorder is nil, no information will be recorded.
 type Settings struct {
 	UseInitialData       bool      // Use supplied information about the conditions at the initial x.
-	InitialFunctionValue float64   // F(x) at the initial x.
+	InitialFunctionValue float64   // Func(x) at the initial x.
 	InitialGradient      []float64 // Df(x) at the initial x.
 
 	// FunctionAbsTol is the threshold for acceptably small values of the
@@ -157,7 +157,7 @@ type Settings struct {
 
 	// FunctionEvals is the maximum allowed number of function evaluations.
 	// FunctionEvaluationLimit status is returned  if the total number of
-	// function evaluations equals or exceeds this number. Calls to F() and
+	// function evaluations equals or exceeds this number. Calls to Func() and
 	// FDf() are both counted as function evaluations for this calculation.
 	// If it equals zero, this setting has no effect.
 	// The default value is 0.

--- a/types.go
+++ b/types.go
@@ -20,7 +20,7 @@ const (
 	NoEvaluation EvaluationType = iota
 	FuncEvaluation
 	GradEvaluation
-	FunctionAndGradientEval
+	FuncGradEvaluation
 )
 
 func (e EvaluationType) String() string {
@@ -34,7 +34,7 @@ var evaluationStrings = [...]string{
 	"NoEvaluation",
 	"FuncEvaluation",
 	"GradEvaluation",
-	"FunctionAndGradientEval",
+	"FuncGradEvaluation",
 }
 
 // IterationType specifies the type of iteration.

--- a/types.go
+++ b/types.go
@@ -18,7 +18,7 @@ type EvaluationType int
 
 const (
 	NoEvaluation EvaluationType = iota
-	FunctionEval
+	FuncEvaluation
 	GradientEval
 	FunctionAndGradientEval
 )
@@ -32,7 +32,7 @@ func (e EvaluationType) String() string {
 
 var evaluationStrings = [...]string{
 	"NoEvaluation",
-	"FunctionEval",
+	"FuncEvaluation",
 	"GradientEval",
 	"FunctionAndGradientEval",
 }

--- a/types.go
+++ b/types.go
@@ -91,7 +91,7 @@ type Result struct {
 type Stats struct {
 	MajorIterations       int           // Total number of major iterations
 	FuncEvaluations       int           // Number of evaluations of Func()
-	GradientEvals         int           // Number of evaluations of Grad()
+	GradEvaluations       int           // Number of evaluations of Grad()
 	FunctionGradientEvals int           // Number of evaluations of FuncGrad()
 	Runtime               time.Duration // Total runtime of the optimization
 }
@@ -163,13 +163,13 @@ type Settings struct {
 	// The default value is 0.
 	FuncEvaluations int
 
-	// GradientEvals is the maximum allowed number of gradient evaluations.
+	// GradEvaluations is the maximum allowed number of gradient evaluations.
 	// GradientEvaluationLimit status is returned if the total number of
 	// gradient evaluations equals or exceeds this number. Calls to Grad() and
 	// FuncGrad() are both counted as gradient evaluations for this calculation.
 	// If it equals zero, this setting has no effect.
 	// The default value is 0.
-	GradientEvals int
+	GradEvaluations int
 
 	Recorder Recorder
 }

--- a/types.go
+++ b/types.go
@@ -19,7 +19,7 @@ type EvaluationType int
 const (
 	NoEvaluation EvaluationType = iota
 	FuncEvaluation
-	GradientEval
+	GradEvaluation
 	FunctionAndGradientEval
 )
 
@@ -33,7 +33,7 @@ func (e EvaluationType) String() string {
 var evaluationStrings = [...]string{
 	"NoEvaluation",
 	"FuncEvaluation",
-	"GradientEval",
+	"GradEvaluation",
 	"FunctionAndGradientEval",
 }
 

--- a/types.go
+++ b/types.go
@@ -89,11 +89,11 @@ type Result struct {
 
 // Stats contains the statistics of the run.
 type Stats struct {
-	MajorIterations       int           // Total number of major iterations
-	FuncEvaluations       int           // Number of evaluations of Func()
-	GradEvaluations       int           // Number of evaluations of Grad()
-	FunctionGradientEvals int           // Number of evaluations of FuncGrad()
-	Runtime               time.Duration // Total runtime of the optimization
+	MajorIterations     int           // Total number of major iterations
+	FuncEvaluations     int           // Number of evaluations of Func()
+	GradEvaluations     int           // Number of evaluations of Grad()
+	FuncGradEvaluations int           // Number of evaluations of FuncGrad()
+	Runtime             time.Duration // Total runtime of the optimization
 }
 
 // FunctionInfo is data to give to the optimizer about the objective function.

--- a/unconstrained_test.go
+++ b/unconstrained_test.go
@@ -497,8 +497,9 @@ func newVariablyDimensioned(dim int, gradTol float64) unconstrainedTest {
 func TestLocal(t *testing.T) {
 	// TODO: When method is nil, Local chooses the method automatically. At
 	// present, it always chooses BFGS (or panics if the function does not
-	// implement Grad() or FDf()). For now, run this test with the simplest set
-	// of problems and revisit this later when more methods are added.
+	// implement Grad() or FuncGrad()). For now, run this test with the
+	// simplest set of problems and revisit this later when more methods are
+	// added.
 	testLocal(t, gradientDescentTests, nil)
 }
 
@@ -674,7 +675,7 @@ func testLocal(t *testing.T, tests []unconstrainedTest, method Method) {
 		var optF, optNorm float64
 		if funcInfo.IsFunctionGradient {
 			g := make([]float64, len(test.x))
-			optF = funcInfo.functionGradient.FDf(result.X, g)
+			optF = funcInfo.functionGradient.FuncGrad(result.X, g)
 			optNorm = floats.Norm(g, math.Inf(1))
 		} else {
 			optF = funcInfo.function.Func(result.X)
@@ -704,7 +705,7 @@ func testLocal(t *testing.T, tests []unconstrainedTest, method Method) {
 		settings.UseInitialData = true
 		if funcInfo.IsFunctionGradient {
 			settings.InitialGradient = resize(settings.InitialGradient, len(test.x))
-			settings.InitialFunctionValue = funcInfo.functionGradient.FDf(test.x, settings.InitialGradient)
+			settings.InitialFunctionValue = funcInfo.functionGradient.FuncGrad(test.x, settings.InitialGradient)
 		} else {
 			settings.InitialFunctionValue = funcInfo.function.Func(test.x)
 			if funcInfo.IsGradient {

--- a/unconstrained_test.go
+++ b/unconstrained_test.go
@@ -497,7 +497,7 @@ func newVariablyDimensioned(dim int, gradTol float64) unconstrainedTest {
 func TestLocal(t *testing.T) {
 	// TODO: When method is nil, Local chooses the method automatically. At
 	// present, it always chooses BFGS (or panics if the function does not
-	// implement Df() or FDf()). For now, run this test with the simplest set
+	// implement Grad() or FDf()). For now, run this test with the simplest set
 	// of problems and revisit this later when more methods are added.
 	testLocal(t, gradientDescentTests, nil)
 }
@@ -680,7 +680,7 @@ func testLocal(t *testing.T, tests []unconstrainedTest, method Method) {
 			optF = funcInfo.function.Func(result.X)
 			if funcInfo.IsGradient {
 				g := make([]float64, len(test.x))
-				funcInfo.gradient.Df(result.X, g)
+				funcInfo.gradient.Grad(result.X, g)
 				optNorm = floats.Norm(g, math.Inf(1))
 			}
 		}
@@ -709,7 +709,7 @@ func testLocal(t *testing.T, tests []unconstrainedTest, method Method) {
 			settings.InitialFunctionValue = funcInfo.function.Func(test.x)
 			if funcInfo.IsGradient {
 				settings.InitialGradient = resize(settings.InitialGradient, len(test.x))
-				funcInfo.gradient.Df(test.x, settings.InitialGradient)
+				funcInfo.gradient.Grad(test.x, settings.InitialGradient)
 			}
 		}
 

--- a/unconstrained_test.go
+++ b/unconstrained_test.go
@@ -743,7 +743,7 @@ func testLocal(t *testing.T, tests []unconstrainedTest, method Method) {
 				continue
 			}
 		} else {
-			if result.FunctionEvals != result2.FunctionEvals+1 {
+			if result.FuncEvaluations != result2.FuncEvaluations+1 {
 				t.Errorf("Providing initial data does not reduce the number of functions calls for:\n%v", test)
 				continue
 			}

--- a/unconstrained_test.go
+++ b/unconstrained_test.go
@@ -738,7 +738,7 @@ func testLocal(t *testing.T, tests []unconstrainedTest, method Method) {
 		// Check that providing initial data reduces the number of function
 		// and/or gradient calls exactly by one.
 		if funcInfo.IsFunctionGradient {
-			if result.FunctionGradientEvals != result2.FunctionGradientEvals+1 {
+			if result.FuncGradEvaluations != result2.FuncGradEvaluations+1 {
 				t.Errorf("Providing initial data does not reduce the number of function/gradient calls for:\n%v", test)
 				continue
 			}

--- a/unconstrained_test.go
+++ b/unconstrained_test.go
@@ -677,7 +677,7 @@ func testLocal(t *testing.T, tests []unconstrainedTest, method Method) {
 			optF = funcInfo.functionGradient.FDf(result.X, g)
 			optNorm = floats.Norm(g, math.Inf(1))
 		} else {
-			optF = funcInfo.function.F(result.X)
+			optF = funcInfo.function.Func(result.X)
 			if funcInfo.IsGradient {
 				g := make([]float64, len(test.x))
 				funcInfo.gradient.Df(result.X, g)
@@ -706,7 +706,7 @@ func testLocal(t *testing.T, tests []unconstrainedTest, method Method) {
 			settings.InitialGradient = resize(settings.InitialGradient, len(test.x))
 			settings.InitialFunctionValue = funcInfo.functionGradient.FDf(test.x, settings.InitialGradient)
 		} else {
-			settings.InitialFunctionValue = funcInfo.function.F(test.x)
+			settings.InitialFunctionValue = funcInfo.function.Func(test.x)
 			if funcInfo.IsGradient {
 				settings.InitialGradient = resize(settings.InitialGradient, len(test.x))
 				funcInfo.gradient.Df(test.x, settings.InitialGradient)

--- a/unconstrained_test.go
+++ b/unconstrained_test.go
@@ -748,7 +748,7 @@ func testLocal(t *testing.T, tests []unconstrainedTest, method Method) {
 				continue
 			}
 			if funcInfo.IsGradient {
-				if result.GradientEvals != result2.GradientEvals+1 {
+				if result.GradEvaluations != result2.GradEvaluations+1 {
 					t.Errorf("Providing initial data does not reduce the number of gradient calls for:\n%v", test)
 					continue
 				}


### PR DESCRIPTION
This PR is proposal how the existing function interfaces could be modified in order to better accomodate functions that can evaluate their Hessian. This prepares the way for an implementation of Newton's method.

At present an objective function can implement the following three methods:
```go
F() // function value
Df() // gradient
FDf() // function value and gradient
```
For the Hessian the natural progression would be
```go
DDf(hess *mat64.SymDense) // hessian
FDfDDf(x float64, grad []float64, hess *mat64.SymDense) // function value, gradient and hessian
```
which I don't like much. Moreover, there is no naming connection to the corresponding EvaluationType and values in Stats and Settings.

Alternatively, the Hessian method could be
```go
Hessian(hess *mat64.SymDense)
```
or
```go
Hess(hess *mat64.SymDense)
```
but in both cases there is the question of how the three-argument method would be called. In any case, this is incosistent with the existing methods.

Yet another alternative is this PR. The interface methods are:
```go
Func()
Grad()
Hess()
FuncGrad()
FuncGradHess()
```
the corresponding evaluation types:
```go
FuncEvaluation
GradEvaluation
HessEvaluation
FuncGradEvaluation
FuncGradHessEvaluation
```
and similarly for Stats and Settings (`FuncEvaluations`, ...), making thus a clear link between methods, evaluation requests from optimizers, settings (limits how many times a method can be called) and stats (how many times a method has actually been called).

PTAL, @btracey @kortschak 


