### PR TITLE
Add Hessian interface

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -4,6 +4,8 @@
 
 package optimize
 
+import "github.com/gonum/matrix/mat64"
+
 // Function evaluates the objective function at the given location. F
 // must not modify x.
 type Function interface {
@@ -16,10 +18,23 @@ type Gradient interface {
 	Grad(x, grad []float64)
 }
 
+// Hessian evaluates the Hessian at x and stores the result in-place in hess.
+// Hess must not modify x.
+type Hessian interface {
+	Hess(x []float64, hess *mat64.SymDense)
+}
+
 // FunctionGradient evaluates both the function and the gradient at x, storing
 // the gradient in-place in grad. FuncGrad must not modify x.
 type FunctionGradient interface {
 	FuncGrad(x, grad []float64) (obj float64)
+}
+
+// FunctionGradientHessian evaluates the function, the gradient and the Hessian
+// at x, storing the gradient and the Hessian in-place in grad and hess,
+// respectively. FuncGradHess must not modify x.
+type FunctionGradientHessian interface {
+	FuncGradHess(x, grad []float64, hess *mat64.SymDense) (obj float64)
 }
 
 // LinesearchMethod is a type that can perform a line search. Typically, these

--- a/local.go
+++ b/local.go
@@ -273,16 +273,23 @@ func checkConvergence(loc *Location, iterType IterationType, stats *Stats, setti
 	}
 
 	if settings.FuncEvaluations > 0 {
-		totalFun := stats.FuncEvaluations + stats.FuncGradEvaluations
+		totalFun := stats.FuncEvaluations + stats.FuncGradEvaluations + stats.FuncGradHessEvaluations
 		if totalFun >= settings.FuncEvaluations {
 			return FunctionEvaluationLimit
 		}
 	}
 
 	if settings.GradEvaluations > 0 {
-		totalGrad := stats.GradEvaluations + stats.FuncGradEvaluations
+		totalGrad := stats.GradEvaluations + stats.FuncGradEvaluations + stats.FuncGradHessEvaluations
 		if totalGrad >= settings.GradEvaluations {
 			return GradientEvaluationLimit
+		}
+	}
+
+	if settings.HessEvaluations > 0 {
+		totalHess := stats.HessEvaluations + stats.FuncGradHessEvaluations
+		if totalHess >= settings.HessEvaluations {
+			return HessianEvaluationLimit
 		}
 	}
 

--- a/termination.go
+++ b/termination.go
@@ -22,6 +22,7 @@ const (
 	RuntimeLimit
 	FunctionEvaluationLimit
 	GradientEvaluationLimit
+	HessianEvaluationLimit
 )
 
 func (s Status) String() string {
@@ -89,6 +90,11 @@ var statuses = []struct {
 		name:  "GradientEvaluationLimit",
 		early: true,
 		err:   errors.New("optimize: maximum number of gradient evaluations reached"),
+	},
+	{
+		name:  "HessianEvaluationLimit",
+		early: true,
+		err:   errors.New("optimize: maximum number of Hessian evaluations reached"),
 	},
 }
 

--- a/types.go
+++ b/types.go
@@ -20,7 +20,9 @@ const (
 	NoEvaluation EvaluationType = iota
 	FuncEvaluation
 	GradEvaluation
+	HessEvaluation
 	FuncGradEvaluation
+	FuncGradHessEvaluation
 )
 
 func (e EvaluationType) String() string {
@@ -34,7 +36,9 @@ var evaluationStrings = [...]string{
 	"NoEvaluation",
 	"FuncEvaluation",
 	"GradEvaluation",
+	"HessEvaluation",
 	"FuncGradEvaluation",
+	"FuncGradHessEvaluation",
 }
 
 // IterationType specifies the type of iteration.

--- a/types.go
+++ b/types.go
@@ -93,11 +93,13 @@ type Result struct {
 
 // Stats contains the statistics of the run.
 type Stats struct {
-	MajorIterations     int           // Total number of major iterations
-	FuncEvaluations     int           // Number of evaluations of Func()
-	GradEvaluations     int           // Number of evaluations of Grad()
-	FuncGradEvaluations int           // Number of evaluations of FuncGrad()
-	Runtime             time.Duration // Total runtime of the optimization
+	MajorIterations         int           // Total number of major iterations
+	FuncEvaluations         int           // Number of evaluations of Func()
+	GradEvaluations         int           // Number of evaluations of Grad()
+	HessEvaluations         int           // Number of evaluations of Hess()
+	FuncGradEvaluations     int           // Number of evaluations of FuncGrad()
+	FuncGradHessEvaluations int           // Number of evaluations of FuncGradHess()
+	Runtime                 time.Duration // Total runtime of the optimization
 }
 
 // FunctionInfo is data to give to the optimizer about the objective function.

--- a/types.go
+++ b/types.go
@@ -163,19 +163,29 @@ type Settings struct {
 
 	// FuncEvaluations is the maximum allowed number of function evaluations.
 	// FunctionEvaluationLimit status is returned if the total number of
-	// function evaluations equals or exceeds this number. Calls to Func() and
-	// FuncGrad() are both counted as function evaluations for this calculation.
+	// function evaluations equals or exceeds this number. Calls to Func(),
+	// FuncGrad() and FuncGradHess() are all counted as function evaluations
+	// for this calculation.
 	// If it equals zero, this setting has no effect.
 	// The default value is 0.
 	FuncEvaluations int
 
 	// GradEvaluations is the maximum allowed number of gradient evaluations.
 	// GradientEvaluationLimit status is returned if the total number of
-	// gradient evaluations equals or exceeds this number. Calls to Grad() and
-	// FuncGrad() are both counted as gradient evaluations for this calculation.
+	// gradient evaluations equals or exceeds this number. Calls to Grad(),
+	// FuncGrad() and FuncGradHess() are all counted as gradient evaluations
+	// for this calculation.
 	// If it equals zero, this setting has no effect.
 	// The default value is 0.
 	GradEvaluations int
+
+	// HessEvaluations is the maximum allowed number of Hessian evaluations.
+	// HessianEvaluationLimit status is returned if the total number of Hessian
+	// evaluations equals or exceeds this number. Calls to Hess() and
+	// FuncGradHess() are both counted as gradient evaluations for this calculation.
+	// If it equals zero, this setting has no effect.
+	// The default value is 0.
+	HessEvaluations int
 
 	Recorder Recorder
 }


### PR DESCRIPTION
Included two commits from #82 and addressed points 1-3 from the discussion therein. PTAL, @btracey .

As I mentioned, we could consider renaming the four statuses so that their name matches the corresponding fields in Settings, e.g. `IterationLimit` to `MajorIterationsLimit`, `HessianEvaluationLimit` to `HessEvaluationsLimit`, ...