### PR TITLE
Add initial Hessian to Settings

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -82,7 +82,7 @@ type Method interface {
 
 	// Needs specifies information about the objective function needed by the
 	// optimizer beyond just the function value. The information is used
-	// internally for initialization and has to match evaluation types returned
+	// internally for initialization and must match evaluation types returned
 	// by Init() and Iterate() during the optimization process.
 	Needs() struct {
 		Gradient bool

--- a/types.go
+++ b/types.go
@@ -157,7 +157,7 @@ func newFunctionInfo(f Function) *functionInfo {
 // constraint interface is designed.
 func (f functionInfo) satisfies(method Method) error {
 	gradOk := f.IsGradient || f.IsFunctionGradient || f.IsFunctionGradientHessian
-	if method.Needs().Gradient && !gradOk {
+	if (method.Needs().Gradient || method.Needs().Hessian) && !gradOk {
 		return errors.New("optimize: function does not implement needed Gradient, FunctionGradient or FunctionGradientHessian interface")
 	}
 	hessOk := f.IsHessian || f.IsFunctionGradientHessian
@@ -171,14 +171,15 @@ func (f functionInfo) satisfies(method Method) error {
 // settings, convergence information, and Recorder information. In general, users
 // should use DefaultSettings() rather than constructing a Settings literal.
 //
-// If UseInitData is true, InitialFunctionValue and InitialGradient specify
-// function information at the initial location.
+// If UseInitData is true, InitialValue, InitialGradient and InitialHessian
+// specify function information at the initial location.
 //
 // If Recorder is nil, no information will be recorded.
 type Settings struct {
-	UseInitialData       bool      // Use supplied information about the conditions at the initial x.
-	InitialFunctionValue float64   // Func(x) at the initial x.
-	InitialGradient      []float64 // Grad(x) at the initial x.
+	UseInitialData  bool            // Use supplied information about the conditions at the initial x.
+	InitialValue    float64         // Func(x) at the initial x.
+	InitialGradient []float64       // Grad(x) at the initial x.
+	InitialHessian  *mat64.SymDense // Hess(x) at the initial x.
 
 	// FunctionThreshold is the threshold for acceptably small values of the
 	// objective function. FunctionThreshold status is returned if

--- a/unconstrained_test.go
+++ b/unconstrained_test.go
@@ -705,9 +705,9 @@ func testLocal(t *testing.T, tests []unconstrainedTest, method Method) {
 		settings.UseInitialData = true
 		if funcInfo.IsFunctionGradient {
 			settings.InitialGradient = resize(settings.InitialGradient, len(test.x))
-			settings.InitialFunctionValue = funcInfo.functionGradient.FuncGrad(test.x, settings.InitialGradient)
+			settings.InitialValue = funcInfo.functionGradient.FuncGrad(test.x, settings.InitialGradient)
 		} else {
-			settings.InitialFunctionValue = funcInfo.function.Func(test.x)
+			settings.InitialValue = funcInfo.function.Func(test.x)
 			if funcInfo.IsGradient {
 				settings.InitialGradient = resize(settings.InitialGradient, len(test.x))
 				funcInfo.gradient.Grad(test.x, settings.InitialGradient)
@@ -716,7 +716,7 @@ func testLocal(t *testing.T, tests []unconstrainedTest, method Method) {
 
 		// Rerun the test again to make sure that it gets the same answer with
 		// the same starting condition. Moreover, we are using the initial data
-		// in settings.InitialFunctionValue and settings.InitialGradient.
+		// in settings.InitialValue and settings.InitialGradient.
 		result2, err2 := Local(test.f, test.x, settings, method)
 		if err2 != nil {
 			t.Errorf("error finding minimum second time (%v) for:\n%v", err2, test)


### PR DESCRIPTION
* Added initial Hessian to Settings
* Changed how the initial location is constructed. The deep nesting in there is not nice and I'd like to get rid of it, but the idea is what matters to me at the moment: the initial function value is used always, but the gradient and Hessian only if they are not nil. If they are, evaluate() is called. If the user wanted to use Newton method on a solution obtained with other gradient-based method, this would be useful. The problem is that if the objective function does not implement methods that directly correspond to evaluation types, we could end up doing more computation than if we just ignored the initial data. We would be doing our best with what the user gave us, but the behaviour might still be slightly surprising and hard to document.

Seeing the code, I think I would revive the idea of putting StartTime into Stats and moving Runtime into Result.

PTAL, @btracey 