### PR TITLE
ORable EvaluationTypes; required Gradient and/or Hessian interfaces

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -24,19 +24,6 @@ type Hessian interface {
 	Hess(x []float64, hess *mat64.SymDense)
 }
 
-// FunctionGradient evaluates both the function and the gradient at x, storing
-// the gradient in-place in grad. FuncGrad must not modify x.
-type FunctionGradient interface {
-	FuncGrad(x, grad []float64) (obj float64)
-}
-
-// FunctionGradientHessian evaluates the function, the gradient and the Hessian
-// at x, storing the gradient and the Hessian in-place in grad and hess,
-// respectively. FuncGradHess must not modify x.
-type FunctionGradientHessian interface {
-	FuncGradHess(x, grad []float64, hess *mat64.SymDense) (obj float64)
-}
-
 // LinesearchMethod is a type that can perform a line search. Typically, these
 // methods will not be called by the user directly, as they will be called by
 // a Linesearch struct.

--- a/local.go
+++ b/local.go
@@ -199,7 +199,7 @@ func copyLocation(dst, src *Location) {
 }
 
 func getDefaultMethod(funcInfo *functionInfo) Method {
-	if funcInfo.IsGradient || funcInfo.IsFunctionGradient {
+	if funcInfo.IsGradient {
 		return &BFGS{}
 	}
 	return &NelderMead{}
@@ -212,7 +212,7 @@ func getStartingLocation(funcInfo *functionInfo, method Method, initX []float64,
 		X: make([]float64, dim),
 	}
 	copy(loc.X, initX)
-	if method.Needs().Gradient || method.Needs().Hessian {
+	if method.Needs().Gradient {
 		loc.Gradient = make([]float64, dim)
 	}
 	if method.Needs().Hessian {

--- a/types.go
+++ b/types.go
@@ -15,33 +15,40 @@ import (
 
 const defaultGradientAbsTol = 1e-6
 
-// EvaluationType is used by the optimizer to specify information needed
-// from the objective function.
-type EvaluationType int
+// EvaluationType is used by a Method to specify the objective-function
+// information needed at an x location. The types can be composed together
+// using the binary or operator, for example 'FuncEvaluation | GradEvaluation'
+// to evaluate both the function value and the gradient.
+type EvaluationType uint
 
+// Basic evaluation types.
 const (
-	NoEvaluation EvaluationType = iota
-	FuncEvaluation
+	NoEvaluation   EvaluationType = 0
+	FuncEvaluation EvaluationType = 1 << iota
 	GradEvaluation
 	HessEvaluation
-	FuncGradEvaluation
-	FuncGradHessEvaluation
+)
+
+// Combined evaluation types.
+const (
+	FuncGradEvaluation     = FuncEvaluation | GradEvaluation
+	FuncGradHessEvaluation = FuncGradEvaluation | HessEvaluation
 )
 
 func (e EvaluationType) String() string {
-	if e < 0 || int(e) >= len(evaluationStrings) {
-		return fmt.Sprintf("EvaluationType(%d)", e)
+	if s, ok := evaluationStrings[e]; ok {
+		return s
 	}
-	return evaluationStrings[e]
+	return fmt.Sprintf("EvaluationType(%d)", e)
 }
 
-var evaluationStrings = [...]string{
-	"NoEvaluation",
-	"FuncEvaluation",
-	"GradEvaluation",
-	"HessEvaluation",
-	"FuncGradEvaluation",
-	"FuncGradHessEvaluation",
+var evaluationStrings = map[EvaluationType]string{
+	NoEvaluation:           "NoEvaluation",
+	FuncEvaluation:         "FuncEvaluation",
+	GradEvaluation:         "GradEvaluation",
+	HessEvaluation:         "HessEvaluation",
+	FuncGradEvaluation:     "FuncGradEvaluation",
+	FuncGradHessEvaluation: "FuncGradHessEvaluation",
 }
 
 // IterationType specifies the type of iteration.

--- a/types.go
+++ b/types.go
@@ -128,35 +128,27 @@ type FunctionInfo struct {
 type functionInfo struct {
 	FunctionInfo
 
-	function                Function
-	gradient                Gradient
-	hessian                 Hessian
-	functionGradient        FunctionGradient
-	functionGradientHessian FunctionGradientHessian
-	statuser                Statuser
+	function Function
+	gradient Gradient
+	hessian  Hessian
+	statuser Statuser
 }
 
 func newFunctionInfo(f Function) *functionInfo {
 	gradient, isGradient := f.(Gradient)
 	hessian, isHessian := f.(Hessian)
-	funcGrad, isFuncGrad := f.(FunctionGradient)
-	funcGradHess, isFuncGradHess := f.(FunctionGradientHessian)
 	statuser, isStatuser := f.(Statuser)
 
 	return &functionInfo{
 		FunctionInfo: FunctionInfo{
-			IsGradient:                isGradient,
-			IsHessian:                 isHessian,
-			IsFunctionGradient:        isFuncGrad,
-			IsFunctionGradientHessian: isFuncGradHess,
-			IsStatuser:                isStatuser,
+			IsGradient: isGradient,
+			IsHessian:  isHessian,
+			IsStatuser: isStatuser,
 		},
-		function:                f,
-		gradient:                gradient,
-		hessian:                 hessian,
-		functionGradient:        funcGrad,
-		functionGradientHessian: funcGradHess,
-		statuser:                statuser,
+		function: f,
+		gradient: gradient,
+		hessian:  hessian,
+		statuser: statuser,
 	}
 }
 

--- a/types.go
+++ b/types.go
@@ -163,13 +163,11 @@ func newFunctionInfo(f Function) *functionInfo {
 // TODO(btracey): Think about making this an exported function when the
 // constraint interface is designed.
 func (f functionInfo) satisfies(method Method) error {
-	gradOk := f.IsGradient || f.IsFunctionGradient || f.IsFunctionGradientHessian
-	if (method.Needs().Gradient || method.Needs().Hessian) && !gradOk {
-		return errors.New("optimize: function does not implement needed Gradient, FunctionGradient or FunctionGradientHessian interface")
+	if method.Needs().Gradient && !f.IsGradient {
+		return errors.New("optimize: function does not implement needed Gradient interface")
 	}
-	hessOk := f.IsHessian || f.IsFunctionGradientHessian
-	if method.Needs().Hessian && !hessOk {
-		return errors.New("optimize: function does not implement needed Hessian or FunctionGradientHessian interface")
+	if method.Needs().Hessian && !f.IsHessian {
+		return errors.New("optimize: function does not implement needed Hessian interface")
 	}
 	return nil
 }

--- a/types.go
+++ b/types.go
@@ -172,6 +172,21 @@ func (f functionInfo) satisfies(method Method) error {
 	return nil
 }
 
+// complementEval returns an evaluation type that evaluates fields of loc not
+// evaluated by eval.
+func complementEval(loc *Location, eval EvaluationType) (complEval EvaluationType) {
+	if eval&FuncEvaluation == 0 {
+		complEval = FuncEvaluation
+	}
+	if loc.Gradient != nil && eval&GradEvaluation == 0 {
+		complEval |= GradEvaluation
+	}
+	if loc.Hessian != nil && eval&HessEvaluation == 0 {
+		complEval |= HessEvaluation
+	}
+	return complEval
+}
+
 // Settings represents settings of the optimization run. It contains initial
 // settings, convergence information, and Recorder information. In general, users
 // should use DefaultSettings() rather than constructing a Settings literal.


### PR DESCRIPTION
A quick, experimental implementation that deals with the problem of too many combinations of what method needs, what function can evaluate, what should be the next evaluation given the previous evaluation, etc.

* Gradient and Hessian interfaces are required if Method.Needs() indicates so
* FunctionGradient and FunctionGradientHessian are optional
* EvaluationTypes are ORable and any combination is acceptable
* loc.Gradient does not need to be allocated if method needs Hessian
* evaluate() is greatly simplified. If we removed the combined, optional interfaces completely, it could be even simpler.
* Adding constraints evaluation in the future would be straightforward

PTAL, @btracey 