### PR TITLE
Remove combined evaluation types

### DIFF
--- a/bisection.go
+++ b/bisection.go
@@ -53,7 +53,7 @@ func (b *Bisection) Init(loc LinesearchLocation, step float64, _ *FunctionInfo) 
 	b.minGrad = loc.Derivative
 	b.maxGrad = math.NaN()
 
-	return FuncGradEvaluation
+	return FuncEvaluation | GradEvaluation
 }
 
 func (b *Bisection) Finished(loc LinesearchLocation) bool {
@@ -72,7 +72,7 @@ func (b *Bisection) Iterate(loc LinesearchLocation) (float64, EvaluationType, er
 			b.maxStep = b.currStep
 			b.maxF = f
 			b.maxGrad = g
-			return b.checkStepEqual((b.minStep+b.maxStep)/2, FuncGradEvaluation)
+			return b.checkStepEqual((b.minStep+b.maxStep)/2, FuncEvaluation|GradEvaluation)
 		case f <= b.minF:
 			// Still haven't found an upper bound, but there is not an increase in
 			// function value and the gradient is still negative, so go more in
@@ -80,7 +80,7 @@ func (b *Bisection) Iterate(loc LinesearchLocation) (float64, EvaluationType, er
 			b.minStep = b.currStep
 			b.minF = f
 			b.minGrad = g
-			return b.checkStepEqual(b.currStep*2, FuncGradEvaluation)
+			return b.checkStepEqual(b.currStep*2, FuncEvaluation|GradEvaluation)
 		default:
 			// Increase in function value, but the gradient is still negative.
 			// Means we must have skipped over a local minimum, so set this point
@@ -88,7 +88,7 @@ func (b *Bisection) Iterate(loc LinesearchLocation) (float64, EvaluationType, er
 			b.maxStep = b.currStep
 			b.maxF = f
 			b.maxGrad = g
-			return b.checkStepEqual((b.minStep+b.maxStep)/2, FuncGradEvaluation)
+			return b.checkStepEqual((b.minStep+b.maxStep)/2, FuncEvaluation|GradEvaluation)
 		}
 	}
 	// We have already bounded the minimum, so we're just working to find one
@@ -112,7 +112,7 @@ func (b *Bisection) Iterate(loc LinesearchLocation) (float64, EvaluationType, er
 		b.maxF = f
 		b.maxGrad = g
 	}
-	return b.checkStepEqual((b.minStep+b.maxStep)/2, FuncGradEvaluation)
+	return b.checkStepEqual((b.minStep+b.maxStep)/2, FuncEvaluation|GradEvaluation)
 }
 
 // checkStepEqual checks if the new step is equal to the old step.

--- a/local.go
+++ b/local.go
@@ -243,13 +243,12 @@ func getStartingLocation(funcInfo *functionInfo, method Method, initX []float64,
 			loc.Hessian.CopySym(initH)
 		}
 	} else {
-		switch {
-		case loc.Hessian != nil:
-			evalType = FuncGradHessEvaluation
-		case loc.Gradient != nil:
-			evalType = FuncGradEvaluation
-		default:
-			evalType = FuncEvaluation
+		evalType = FuncEvaluation
+		if loc.Gradient != nil {
+			evalType |= GradEvaluation
+		}
+		if loc.Hessian != nil {
+			evalType |= HessEvaluation
 		}
 		evaluate(funcInfo, evalType, loc.X, loc, stats)
 	}
@@ -299,22 +298,19 @@ func checkConvergence(loc *Location, iterType IterationType, stats *Stats, setti
 	}
 
 	if settings.FuncEvaluations > 0 {
-		totalFun := stats.FuncEvaluations + stats.FuncGradEvaluations + stats.FuncGradHessEvaluations
-		if totalFun >= settings.FuncEvaluations {
+		if stats.FuncEvaluations >= settings.FuncEvaluations {
 			return FunctionEvaluationLimit
 		}
 	}
 
 	if settings.GradEvaluations > 0 {
-		totalGrad := stats.GradEvaluations + stats.FuncGradEvaluations + stats.FuncGradHessEvaluations
-		if totalGrad >= settings.GradEvaluations {
+		if stats.GradEvaluations >= settings.GradEvaluations {
 			return GradientEvaluationLimit
 		}
 	}
 
 	if settings.HessEvaluations > 0 {
-		totalHess := stats.HessEvaluations + stats.FuncGradHessEvaluations
-		if totalHess >= settings.HessEvaluations {
+		if stats.HessEvaluations >= settings.HessEvaluations {
 			return HessianEvaluationLimit
 		}
 	}

--- a/printer.go
+++ b/printer.go
@@ -71,7 +71,7 @@ func (p *Printer) Record(loc *Location, _ EvaluationType, iter IterationType, st
 	// Make the value strings
 	var valueStrings [nPrinterOut]string
 	valueStrings[0] = strconv.Itoa(stats.MajorIterations)
-	valueStrings[1] = strconv.Itoa(stats.FuncEvaluations + stats.FuncGradEvaluations)
+	valueStrings[1] = strconv.Itoa(stats.FuncEvaluations)
 	valueStrings[2] = fmt.Sprintf("%g", loc.F)
 	if p.printGrad {
 		norm := floats.Norm(loc.Gradient, math.Inf(1))

--- a/types.go
+++ b/types.go
@@ -16,23 +16,17 @@ import (
 const defaultGradientAbsTol = 1e-6
 
 // EvaluationType is used by a Method to specify the objective-function
-// information needed at an x location. The types can be composed together
-// using the binary or operator, for example 'FuncEvaluation | GradEvaluation'
-// to evaluate both the function value and the gradient.
+// information needed at an x location.
 type EvaluationType uint
 
-// Basic evaluation types.
+// Evaluation types can be composed together using the binary or operator, for
+// example 'FuncEvaluation | GradEvaluation' to evaluate both the function
+// value and the gradient.
 const (
 	NoEvaluation   EvaluationType = 0
 	FuncEvaluation EvaluationType = 1 << iota
 	GradEvaluation
 	HessEvaluation
-)
-
-// Combined evaluation types.
-const (
-	FuncGradEvaluation     = FuncEvaluation | GradEvaluation
-	FuncGradHessEvaluation = FuncGradEvaluation | HessEvaluation
 )
 
 func (e EvaluationType) String() string {
@@ -43,12 +37,10 @@ func (e EvaluationType) String() string {
 }
 
 var evaluationStrings = map[EvaluationType]string{
-	NoEvaluation:           "NoEvaluation",
-	FuncEvaluation:         "FuncEvaluation",
-	GradEvaluation:         "GradEvaluation",
-	HessEvaluation:         "HessEvaluation",
-	FuncGradEvaluation:     "FuncGradEvaluation",
-	FuncGradHessEvaluation: "FuncGradHessEvaluation",
+	NoEvaluation:   "NoEvaluation",
+	FuncEvaluation: "FuncEvaluation",
+	GradEvaluation: "GradEvaluation",
+	HessEvaluation: "HessEvaluation",
 }
 
 // IterationType specifies the type of iteration.
@@ -104,13 +96,11 @@ type Result struct {
 
 // Stats contains the statistics of the run.
 type Stats struct {
-	MajorIterations         int           // Total number of major iterations
-	FuncEvaluations         int           // Number of evaluations of Func()
-	GradEvaluations         int           // Number of evaluations of Grad()
-	HessEvaluations         int           // Number of evaluations of Hess()
-	FuncGradEvaluations     int           // Number of evaluations of FuncGrad()
-	FuncGradHessEvaluations int           // Number of evaluations of FuncGradHess()
-	Runtime                 time.Duration // Total runtime of the optimization
+	MajorIterations int           // Total number of major iterations
+	FuncEvaluations int           // Number of evaluations of Func()
+	GradEvaluations int           // Number of evaluations of Grad()
+	HessEvaluations int           // Number of evaluations of Hess()
+	Runtime         time.Duration // Total runtime of the optimization
 }
 
 // FunctionInfo is data to give to the optimizer about the objective function.
@@ -229,27 +219,22 @@ type Settings struct {
 	Runtime time.Duration
 
 	// FuncEvaluations is the maximum allowed number of function evaluations.
-	// FunctionEvaluationLimit status is returned if the total number of
-	// function evaluations equals or exceeds this number. Calls to Func(),
-	// FuncGrad() and FuncGradHess() are all counted as function evaluations
-	// for this calculation.
+	// FunctionEvaluationLimit status is returned if the total number of calls
+	// to Func() equals or exceeds this number.
 	// If it equals zero, this setting has no effect.
 	// The default value is 0.
 	FuncEvaluations int
 
 	// GradEvaluations is the maximum allowed number of gradient evaluations.
-	// GradientEvaluationLimit status is returned if the total number of
-	// gradient evaluations equals or exceeds this number. Calls to Grad(),
-	// FuncGrad() and FuncGradHess() are all counted as gradient evaluations
-	// for this calculation.
+	// GradientEvaluationLimit status is returned if the total number of calls
+	// to Grad() equals or exceeds this number.
 	// If it equals zero, this setting has no effect.
 	// The default value is 0.
 	GradEvaluations int
 
 	// HessEvaluations is the maximum allowed number of Hessian evaluations.
-	// HessianEvaluationLimit status is returned if the total number of Hessian
-	// evaluations equals or exceeds this number. Calls to Hess() and
-	// FuncGradHess() are both counted as gradient evaluations for this calculation.
+	// HessianEvaluationLimit status is returned if the total number of calls
+	// to Hess() equals or exceeds this number.
 	// If it equals zero, this setting has no effect.
 	// The default value is 0.
 	HessEvaluations int

--- a/types.go
+++ b/types.go
@@ -24,23 +24,17 @@ type EvaluationType uint
 // value and the gradient.
 const (
 	NoEvaluation   EvaluationType = 0
-	FuncEvaluation EvaluationType = 1 << iota
+	FuncEvaluation EvaluationType = 1 << (iota - 1)
 	GradEvaluation
 	HessEvaluation
 )
 
 func (e EvaluationType) String() string {
-	if s, ok := evaluationStrings[e]; ok {
-		return s
-	}
-	return fmt.Sprintf("EvaluationType(%d)", e)
-}
-
-var evaluationStrings = map[EvaluationType]string{
-	NoEvaluation:   "NoEvaluation",
-	FuncEvaluation: "FuncEvaluation",
-	GradEvaluation: "GradEvaluation",
-	HessEvaluation: "HessEvaluation",
+	return fmt.Sprintf("EvaluationType(Func: %t, Grad: %t, Hess: %t, Extra: 0b%b)",
+		e&FuncEvaluation != 0,
+		e&GradEvaluation != 0,
+		e&HessEvaluation != 0,
+		e&^(FuncEvaluation|GradEvaluation|HessEvaluation))
 }
 
 // IterationType specifies the type of iteration.


### PR DESCRIPTION
PTAL, @btracey 

In the end I decided to format EvaluationType using your suggestion. Using just `EvaluationType(number)` would be also fine, because non-implementers of outside Methods would almost never get to see evaluation types default formatted, only possibly via Recorders. On the other hand, implementers of Methods could get to see a default-formatted evaluation type in a panic, in which case a better formatted information could be handy.