### PR TITLE
Clean Printer and change Recorder interface

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -95,6 +95,6 @@ type Statuser interface {
 // A Recorder can record the progress of the optimization, for example to print
 // the progress to StdOut or to a log file. A Recorder must not modify any data.
 type Recorder interface {
-	Init(*FunctionInfo) error
+	Init() error
 	Record(*Location, EvaluationType, IterationType, *Stats) error
 }

--- a/local.go
+++ b/local.go
@@ -76,8 +76,8 @@ func Local(f Function, initX []float64, settings *Settings, method Method) (*Res
 
 	if settings.Recorder != nil {
 		// Initialize Recorder first. If it fails, we avoid the (possibly
-		// time-consuming) evaluation of F and DF at the starting location.
-		err := settings.Recorder.Init(&funcInfo.FunctionInfo)
+		// time-consuming) evaluation of Func() and Grad() at the starting location.
+		err := settings.Recorder.Init()
 		if err != nil {
 			return nil, err
 		}

--- a/printer.go
+++ b/printer.go
@@ -25,7 +25,7 @@ var printerHeadings = [...]string{
 }
 
 const (
-	printerBaseTmpl = "%6v  %12v  %9v  %22v" // Base template for headings and values that are always printed.
+	printerBaseTmpl = "%9v  %16v  %9v  %22v" // Base template for headings and values that are always printed.
 	printerGradTmpl = "  %9v  %22v"          // Appended to base template when loc.Gradient != nil.
 	printerHessTmpl = "  %9v"                // Appended to base template when loc.Hessian != nil.
 )

--- a/printer.go
+++ b/printer.go
@@ -9,22 +9,35 @@ import (
 	"io"
 	"math"
 	"os"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/gonum/floats"
 )
 
+var printerHeadings = [...]string{
+	"Iter",
+	"Runtime",
+	"FuncEvals",
+	"Func",
+	"GradEvals",
+	"|Gradient|∞",
+	"HessEvals",
+}
+
+const (
+	printerBaseTmpl = "%6v  %12v  %9v  %22v" // Base template for headings and values that are always printed.
+	printerGradTmpl = "  %9v  %22v"          // Appended to base template when loc.Gradient != nil.
+	printerHessTmpl = "  %9v"                // Appended to base template when loc.Hessian != nil.
+)
+
 // Printer writes column-format output to the specified writer as the optimization
-// progresses. By default, it writes to Stdout.
+// progresses. By default, it writes to os.Stdout.
 type Printer struct {
 	Writer          io.Writer
 	HeadingInterval int
 	ValueInterval   time.Duration
 
 	lastHeading int
-	printGrad   bool
 	lastValue   time.Time
 }
 
@@ -36,112 +49,58 @@ func NewPrinter() *Printer {
 	}
 }
 
-const nPrinterOut = len(printerHeadings)
-
-var (
-	printerHeadings = [...]string{
-		"Iter",
-		"FunEval",
-		"Obj",
-		"GradNorm",
-	}
-)
-
-func (p *Printer) Init(f *FunctionInfo) error {
-	p.printGrad = f.IsFunctionGradient || f.IsGradient
-
-	p.lastHeading = p.HeadingInterval + 1          // So the headings are printed the first time
-	p.lastValue = time.Now().Add(-p.ValueInterval) // So the values are printed the first time
+func (p *Printer) Init(_ *FunctionInfo) error {
+	p.lastHeading = p.HeadingInterval              // So the headings are printed the first time.
+	p.lastValue = time.Now().Add(-p.ValueInterval) // So the values are printed the first time.
 	return nil
 }
 
 func (p *Printer) Record(loc *Location, _ EvaluationType, iter IterationType, stats *Stats) error {
-	// Only print on major and initial iterations, or if the iteration is over.
 	if iter != MajorIteration && iter != InitIteration && iter != PostIteration {
 		return nil
 	}
 
-	var nPrint int
-	if p.printGrad {
-		nPrint = nPrinterOut
+	// Print values always on PostIteration or when ValueInterval has elapsed.
+	printValues := time.Since(p.lastValue) > p.ValueInterval || iter == PostIteration
+	if !printValues {
+		// Return early if not printing anything.
+		return nil
+	}
+
+	// Print heading when HeadingInterval lines have been printed, but never on PostIteration.
+	printHeading := p.lastHeading >= p.HeadingInterval && iter != PostIteration
+	if printHeading {
+		p.lastHeading = 1
 	} else {
-		nPrint = nPrinterOut - 1
-	}
-
-	// Make the value strings
-	var valueStrings [nPrinterOut]string
-	valueStrings[0] = strconv.Itoa(stats.MajorIterations)
-	valueStrings[1] = strconv.Itoa(stats.FuncEvaluations)
-	valueStrings[2] = fmt.Sprintf("%g", loc.F)
-	if p.printGrad {
-		norm := floats.Norm(loc.Gradient, math.Inf(1))
-		valueStrings[3] = fmt.Sprintf("%g", norm)
-	}
-
-	var maxLengths [nPrinterOut]int
-
-	for i := 0; i < nPrint; i++ {
-		v := len(printerHeadings[i])
-		v2 := len(valueStrings[i])
-		if v > v2 {
-			maxLengths[i] = v
-			continue
-		}
-		maxLengths[i] = v2
-	}
-
-	// First, see if we want to print the headings. Don't print for final.
-	if p.lastHeading >= p.HeadingInterval && iter != PostIteration {
-		// Yes we do
-		p.lastHeading = 0
-
-		headingString := constructPrinterString(printerHeadings, maxLengths, nPrint)
-		// Add an extra newline to heading string
-		headingString = "\n" + headingString
-
-		_, err := p.Writer.Write([]byte(headingString))
-		if err != nil {
-			return err
-		}
-
-	}
-	// See if we want to print the value. Always print for final.
-	if iter == PostIteration || time.Since(p.lastValue) > p.ValueInterval {
-		// Yes we do
 		p.lastHeading++
-		p.lastValue = time.Now()
+	}
 
-		valueString := constructPrinterString(valueStrings, maxLengths, nPrint)
-		_, err := p.Writer.Write([]byte(valueString))
+	if printHeading {
+		headings := "\n" + fmt.Sprintf(printerBaseTmpl, printerHeadings[0], printerHeadings[1], printerHeadings[2], printerHeadings[3])
+		if loc.Gradient != nil {
+			headings += fmt.Sprintf(printerGradTmpl, printerHeadings[4], printerHeadings[5])
+		}
+		if loc.Hessian != nil {
+			headings += fmt.Sprintf(printerHessTmpl, printerHeadings[6])
+		}
+		_, err := fmt.Fprintln(p.Writer, headings)
 		if err != nil {
 			return err
 		}
 	}
+
+	values := fmt.Sprintf(printerBaseTmpl, stats.MajorIterations, stats.Runtime, stats.FuncEvaluations, loc.F)
+	if loc.Gradient != nil {
+		values += fmt.Sprintf(printerGradTmpl, stats.GradEvaluations, floats.Norm(loc.Gradient, math.Inf(1)))
+	}
+	if loc.Hessian != nil {
+		values += fmt.Sprintf(printerHessTmpl, stats.HessEvaluations)
+	}
+	_, err := fmt.Fprintln(p.Writer, values)
+	if err != nil {
+		return err
+	}
+
+	p.lastValue = time.Now()
 	return nil
-}
-
-// pad string adds spaces onto the end of the string to make it the correct length
-func padString(s string, l int) string {
-	if len(s) > l {
-		panic("optimize: string too long")
-	}
-	if len(s) == l {
-		return s
-	}
-	nShort := l - len(s)
-	return s + strings.Repeat(" ", nShort)
-}
-
-func constructPrinterString(values [nPrinterOut]string, maxLengths [nPrinterOut]int, nPrint int) string {
-	var str string
-	for i := 0; i < nPrint; i++ {
-		s := values[i]
-		s = padString(s, maxLengths[i])
-		str += s
-		if i != nPrint-1 {
-			str += "\t"
-		}
-	}
-	str += "\n"
-	return str
 }

--- a/printer.go
+++ b/printer.go
@@ -49,7 +49,7 @@ func NewPrinter() *Printer {
 	}
 }
 
-func (p *Printer) Init(_ *FunctionInfo) error {
+func (p *Printer) Init() error {
 	p.lastHeading = p.HeadingInterval              // So the headings are printed the first time.
 	p.lastValue = time.Now().Add(-p.ValueInterval) // So the values are printed the first time.
 	return nil

--- a/types.go
+++ b/types.go
@@ -241,7 +241,6 @@ func DefaultSettings() *Settings {
 	return &Settings{
 		GradientThreshold: defaultGradientAbsTol,
 		FunctionThreshold: math.Inf(-1),
-		Recorder:          NewPrinter(),
 		FunctionConverge: &FunctionConverge{
 			Absolute:   1e-10,
 			Iterations: 20,


### PR DESCRIPTION
* Make optimize silent by default
* Simplify Printer
* Change the printout format so that is is as fixed-width as possible for a majority of optimization runs.
* Remove FunctionInfo argument from Recorder.Init(). There is no reason why a Recorder should need information about the objective function for its initialization

PTAL @btracey 