### PR TITLE
Remove unnecessary ProblemInfo

### DIFF
--- a/backtracking.go
+++ b/backtracking.go
@@ -32,7 +32,7 @@ type Backtracking struct {
 	initG    float64
 }
 
-func (b *Backtracking) Init(loc LinesearchLocation, step float64, _ *ProblemInfo) EvaluationType {
+func (b *Backtracking) Init(loc LinesearchLocation, step float64) EvaluationType {
 	if step <= 0 {
 		panic("backtracking: bad step size")
 	}

--- a/bfgs.go
+++ b/bfgs.go
@@ -41,7 +41,7 @@ type BFGS struct {
 // NOTE: This method exists so that it's easier to use a bfgs algorithm because
 // it implements Method
 
-func (b *BFGS) Init(loc *Location, p *ProblemInfo, xNext []float64) (EvaluationType, IterationType, error) {
+func (b *BFGS) Init(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {
 	if b.LinesearchMethod == nil {
 		b.LinesearchMethod = &Bisection{}
 	}
@@ -51,7 +51,7 @@ func (b *BFGS) Init(loc *Location, p *ProblemInfo, xNext []float64) (EvaluationT
 	b.linesearch.Method = b.LinesearchMethod
 	b.linesearch.NextDirectioner = b
 
-	return b.linesearch.Init(loc, p, xNext)
+	return b.linesearch.Init(loc, xNext)
 }
 
 func (b *BFGS) Iterate(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {

--- a/bisection.go
+++ b/bisection.go
@@ -26,7 +26,7 @@ type Bisection struct {
 	maxGrad  float64
 }
 
-func (b *Bisection) Init(loc LinesearchLocation, step float64, _ *ProblemInfo) EvaluationType {
+func (b *Bisection) Init(loc LinesearchLocation, step float64) EvaluationType {
 	if loc.Derivative >= 0 {
 		panic("bisection: init G non-negative")
 	}

--- a/cg.go
+++ b/cg.go
@@ -94,7 +94,7 @@ type CG struct {
 	gradPrevNorm float64
 }
 
-func (cg *CG) Init(loc *Location, p *ProblemInfo, xNext []float64) (EvaluationType, IterationType, error) {
+func (cg *CG) Init(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {
 	if cg.IterationRestartFactor < 0 {
 		panic("cg: IterationRestartFactor is negative")
 	}
@@ -125,7 +125,7 @@ func (cg *CG) Init(loc *Location, p *ProblemInfo, xNext []float64) (EvaluationTy
 	cg.linesearch.Method = cg.LinesearchMethod
 	cg.linesearch.NextDirectioner = cg
 
-	return cg.linesearch.Init(loc, p, xNext)
+	return cg.linesearch.Init(loc, xNext)
 }
 
 func (cg *CG) Iterate(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {

--- a/gradientdescent.go
+++ b/gradientdescent.go
@@ -18,7 +18,7 @@ type GradientDescent struct {
 	linesearch *Linesearch
 }
 
-func (g *GradientDescent) Init(loc *Location, p *ProblemInfo, xNext []float64) (EvaluationType, IterationType, error) {
+func (g *GradientDescent) Init(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {
 	if g.StepSizer == nil {
 		g.StepSizer = &QuadraticStepSize{}
 	}
@@ -31,7 +31,7 @@ func (g *GradientDescent) Init(loc *Location, p *ProblemInfo, xNext []float64) (
 	g.linesearch.Method = g.LinesearchMethod
 	g.linesearch.NextDirectioner = g
 
-	return g.linesearch.Init(loc, p, xNext)
+	return g.linesearch.Init(loc, xNext)
 }
 
 func (g *GradientDescent) Iterate(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {

--- a/interfaces.go
+++ b/interfaces.go
@@ -11,7 +11,7 @@ type LinesearchMethod interface {
 	// Init initializes the linesearch method. LinesearchLocation contains the
 	// function information at step == 0, and step contains the first step length
 	// as specified by the NextDirectioner.
-	Init(loc LinesearchLocation, step float64, p *ProblemInfo) EvaluationType
+	Init(loc LinesearchLocation, step float64) EvaluationType
 
 	// Finished takes in the function result at the most recent linesearch location,
 	// and returns true if the line search has been concluded.
@@ -42,7 +42,7 @@ type NextDirectioner interface {
 // A Method can optimize an objective function.
 type Method interface {
 	// Initializes the method and returns the first location to evaluate
-	Init(loc *Location, p *ProblemInfo, xNext []float64) (EvaluationType, IterationType, error)
+	Init(loc *Location, xNext []float64) (EvaluationType, IterationType, error)
 
 	// Stores the next location to evaluate in xNext
 	Iterate(loc *Location, xNext []float64) (EvaluationType, IterationType, error)

--- a/lbfgs.go
+++ b/lbfgs.go
@@ -38,7 +38,7 @@ type LBFGS struct {
 	rhoHist []float64   // last Store iterations of rho
 }
 
-func (l *LBFGS) Init(loc *Location, p *ProblemInfo, xNext []float64) (EvaluationType, IterationType, error) {
+func (l *LBFGS) Init(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {
 	if l.LinesearchMethod == nil {
 		l.LinesearchMethod = &Bisection{}
 	}
@@ -47,7 +47,7 @@ func (l *LBFGS) Init(loc *Location, p *ProblemInfo, xNext []float64) (Evaluation
 	}
 	l.linesearch.Method = l.LinesearchMethod
 	l.linesearch.NextDirectioner = l
-	return l.linesearch.Init(loc, p, xNext)
+	return l.linesearch.Init(loc, xNext)
 }
 
 func (l *LBFGS) Iterate(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {

--- a/linesearch.go
+++ b/linesearch.go
@@ -21,13 +21,11 @@ type Linesearch struct {
 	initX []float64
 	dir   []float64
 
-	probInfo *ProblemInfo
-
 	lastEvalType EvaluationType
 	iterType     IterationType
 }
 
-func (ls *Linesearch) Init(loc *Location, p *ProblemInfo, xNext []float64) (EvaluationType, IterationType, error) {
+func (ls *Linesearch) Init(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {
 	ls.initX = resize(ls.initX, len(loc.X))
 	copy(ls.initX, loc.X)
 
@@ -45,9 +43,8 @@ func (ls *Linesearch) Init(loc *Location, p *ProblemInfo, xNext []float64) (Eval
 		F:          loc.F,
 		Derivative: projGrad,
 	}
-	evalType := ls.Method.Init(lsLoc, stepSize, p)
+	evalType := ls.Method.Init(lsLoc, stepSize)
 	floats.AddScaledTo(xNext, ls.initX, stepSize, ls.dir)
-	ls.probInfo = p
 	ls.lastEvalType = evalType
 	ls.iterType = MinorIteration
 	return evalType, ls.iterType, nil
@@ -120,7 +117,7 @@ func (ls *Linesearch) initNextLinesearch(loc *Location, xNext []float64) (Evalua
 		F:          loc.F,
 		Derivative: projGrad,
 	}
-	evalType := ls.Method.Init(lsLoc, stepsize, ls.probInfo)
+	evalType := ls.Method.Init(lsLoc, stepsize)
 	floats.AddScaledTo(xNext, ls.initX, stepsize, ls.dir)
 	// Compare the starting point for the current iteration with the next
 	// evaluation point to make sure that rounding errors do not prevent progress.

--- a/local.go
+++ b/local.go
@@ -131,7 +131,7 @@ func minimize(settings *Settings, method Method, p *Problem, stats *Stats, optLo
 
 	methodStatus, methodIsStatuser := method.(Statuser)
 
-	evalType, iterType, err := method.Init(loc, newProblemInfo(p), xNext)
+	evalType, iterType, err := method.Init(loc, xNext)
 	if err != nil {
 		return Failure, err
 	}

--- a/neldermead.go
+++ b/neldermead.go
@@ -81,7 +81,7 @@ type NelderMead struct {
 	reflectedValue float64    // Value at the last reflection point
 }
 
-func (n *NelderMead) Init(loc *Location, p *ProblemInfo, xNext []float64) (EvaluationType, IterationType, error) {
+func (n *NelderMead) Init(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {
 	dim := len(loc.X)
 	if cap(n.vertices) < dim+1 {
 		n.vertices = make([][]float64, dim+1)

--- a/newton.go
+++ b/newton.go
@@ -54,7 +54,7 @@ type Newton struct {
 	tau  float64
 }
 
-func (n *Newton) Init(loc *Location, p *ProblemInfo, xNext []float64) (EvaluationType, IterationType, error) {
+func (n *Newton) Init(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {
 	if n.Increase == 0 {
 		n.Increase = 5
 	}
@@ -70,7 +70,7 @@ func (n *Newton) Init(loc *Location, p *ProblemInfo, xNext []float64) (Evaluatio
 	n.linesearch.Method = n.LinesearchMethod
 	n.linesearch.NextDirectioner = n
 
-	return n.linesearch.Init(loc, p, xNext)
+	return n.linesearch.Init(loc, xNext)
 }
 
 func (n *Newton) Iterate(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {

--- a/types.go
+++ b/types.go
@@ -97,19 +97,6 @@ type Stats struct {
 	Runtime         time.Duration // Total runtime of the optimization
 }
 
-// ProblemInfo is data to give to the optimizer about the objective function.
-type ProblemInfo struct {
-	HasGradient bool
-	HasHessian  bool
-}
-
-func newProblemInfo(p *Problem) *ProblemInfo {
-	return &ProblemInfo{
-		HasGradient: p.Grad != nil,
-		HasHessian:  p.Hess != nil,
-	}
-}
-
 // complementEval returns an evaluation type that evaluates fields of loc not
 // evaluated by eval.
 func complementEval(loc *Location, eval EvaluationType) (complEval EvaluationType) {


### PR DESCRIPTION
Discussion in #110 implies that `Method` cannot make any use of `ProblemInfo` which therefore becomes unnecessary.

PTAL, @btracey 