### PR TITLE
Clean and improve Linesearch code

### DIFF
--- a/backtracking.go
+++ b/backtracking.go
@@ -5,13 +5,13 @@
 package optimize
 
 const (
-	defaultBacktrackingDecrease = 0.5
-	defaultBacktrackingFunConst = 1e-4
-	minimumBacktrackingStepSize = 1e-20
+	defaultBacktrackingDecrease  = 0.5
+	defaultBacktrackingFuncConst = 1e-4
+	minimumBacktrackingStepSize  = 1e-20
 )
 
 // Backtracking is a Linesearcher that uses a backtracking to find a point that
-// satisfies the Armijo condition with the given function constant FunConst. If
+// satisfies the Armijo condition with the given function constant FuncConst. If
 // the Armijo condition has not been met, the step size is decreased by a
 // factor of Decrease.
 //
@@ -21,12 +21,12 @@ const (
 // not appropriate for optimizers that require the Wolfe conditions to be met,
 // such as BFGS.
 //
-// Both FunConst and Decrease must be between zero and one, and Backtracking will
-// panic otherwise. If either FunConst or Decrease are zero, it will be set to a
+// Both FuncConst and Decrease must be between zero and one, and Backtracking will
+// panic otherwise. If either FuncConst or Decrease are zero, it will be set to a
 // reasonable default.
 type Backtracking struct {
-	FunConst float64 // Necessary function descrease for Armijo condition.
-	Decrease float64 // Step size multiplier at each iteration (stepSize *= Decrease).
+	FuncConst float64 // Necessary function descrease for Armijo condition.
+	Decrease  float64 // Step size multiplier at each iteration (stepSize *= Decrease).
 
 	stepSize float64
 	initF    float64
@@ -44,14 +44,14 @@ func (b *Backtracking) Init(f, g float64, step float64) EvaluationType {
 	if b.Decrease == 0 {
 		b.Decrease = defaultBacktrackingDecrease
 	}
-	if b.FunConst == 0 {
-		b.FunConst = defaultBacktrackingFunConst
+	if b.FuncConst == 0 {
+		b.FuncConst = defaultBacktrackingFuncConst
 	}
 	if b.Decrease <= 0 || b.Decrease >= 1 {
 		panic("backtracking: Decrease must be between 0 and 1")
 	}
-	if b.FunConst <= 0 || b.FunConst >= 1 {
-		panic("backtracking: FunConst must be between 0 and 1")
+	if b.FuncConst <= 0 || b.FuncConst >= 1 {
+		panic("backtracking: FuncConst must be between 0 and 1")
 	}
 
 	b.stepSize = step
@@ -61,7 +61,7 @@ func (b *Backtracking) Init(f, g float64, step float64) EvaluationType {
 }
 
 func (b *Backtracking) Finished(f, _ float64) bool {
-	return ArmijoConditionMet(f, b.initF, b.initG, b.stepSize, b.FunConst)
+	return ArmijoConditionMet(f, b.initF, b.initG, b.stepSize, b.FuncConst)
 }
 
 func (b *Backtracking) Iterate(_, _ float64) (float64, EvaluationType, error) {

--- a/backtracking.go
+++ b/backtracking.go
@@ -10,15 +10,16 @@ const (
 	minimumBacktrackingStepSize = 1e-20
 )
 
-// Backtracking is a type that implements LinesearchMethod using a backtracking
-// line search. A backtracking line search checks that the Armijo condition has
-// been met with the given function constant. If the Armijo condition has not
-// been met, the step size is decreased by a factor of Decrease.
+// Backtracking is a Linesearcher that uses a backtracking to find a point that
+// satisfies the Armijo condition with the given function constant FunConst. If
+// the Armijo condition has not been met, the step size is decreased by a
+// factor of Decrease.
 //
-// The Armijo conditions only require the gradient at the initial condition
-// (not successive step locations), and so Backtracking may be a good linesearch
-// method for functions with expensive gradients. Backtracking is not appropriate
-// for optimizers that require the Wolfe conditions to be met, such as BFGS.
+// The Armijo condition only requires the gradient at the beginning of each
+// major iteration (not at successive step locations), and so Backtracking may
+// be a good linesearch for functions with expensive gradients. Backtracking is
+// not appropriate for optimizers that require the Wolfe conditions to be met,
+// such as BFGS.
 //
 // Both FunConst and Decrease must be between zero and one, and Backtracking will
 // panic otherwise. If either FunConst or Decrease are zero, it will be set to a

--- a/backtracking.go
+++ b/backtracking.go
@@ -10,7 +10,7 @@ const (
 	minimumBacktrackingStepSize  = 1e-20
 )
 
-// Backtracking is a Linesearcher that uses a backtracking to find a point that
+// Backtracking is a Linesearcher that uses backtracking to find a point that
 // satisfies the Armijo condition with the given function constant FuncConst. If
 // the Armijo condition has not been met, the step size is decreased by a
 // factor of Decrease.

--- a/backtracking.go
+++ b/backtracking.go
@@ -33,11 +33,11 @@ type Backtracking struct {
 }
 
 func (b *Backtracking) Init(f, g float64, step float64) EvaluationType {
-	if g >= 0 {
-		panic("backtracking: initial derivative is non-negative")
-	}
 	if step <= 0 {
 		panic("backtracking: bad step size")
+	}
+	if g >= 0 {
+		panic("backtracking: initial derivative is non-negative")
 	}
 
 	if b.Decrease == 0 {

--- a/backtracking.go
+++ b/backtracking.go
@@ -32,12 +32,12 @@ type Backtracking struct {
 	initG    float64
 }
 
-func (b *Backtracking) Init(loc LinesearchLocation, step float64) EvaluationType {
+func (b *Backtracking) Init(f, g float64, step float64) EvaluationType {
+	if g >= 0 {
+		panic("backtracking: initial derivative is non-negative")
+	}
 	if step <= 0 {
 		panic("backtracking: bad step size")
-	}
-	if loc.Derivative >= 0 {
-		panic("Backtracking: init G non-negative")
 	}
 
 	if b.Decrease == 0 {
@@ -54,16 +54,16 @@ func (b *Backtracking) Init(loc LinesearchLocation, step float64) EvaluationType
 	}
 
 	b.stepSize = step
-	b.initF = loc.F
-	b.initG = loc.Derivative
+	b.initF = f
+	b.initG = g
 	return FuncEvaluation
 }
 
-func (b *Backtracking) Finished(loc LinesearchLocation) bool {
-	return ArmijoConditionMet(loc.F, b.initF, b.initG, b.stepSize, b.FunConst)
+func (b *Backtracking) Finished(f, _ float64) bool {
+	return ArmijoConditionMet(f, b.initF, b.initG, b.stepSize, b.FunConst)
 }
 
-func (b *Backtracking) Iterate(_ LinesearchLocation) (float64, EvaluationType, error) {
+func (b *Backtracking) Iterate(_, _ float64) (float64, EvaluationType, error) {
 	b.stepSize *= b.Decrease
 	if b.stepSize < minimumBacktrackingStepSize {
 		return 0, NoEvaluation, ErrLinesearchFailure

--- a/bfgs.go
+++ b/bfgs.go
@@ -20,7 +20,7 @@ import (
 type BFGS struct {
 	Linesearcher Linesearcher
 
-	ls *LinesearchHelper
+	ls *LinesearchMethod
 
 	x    []float64 // location of the last major iteration
 	grad []float64 // gradient at the last major iteration
@@ -44,7 +44,7 @@ func (b *BFGS) Init(loc *Location, xNext []float64) (EvaluationType, IterationTy
 		b.Linesearcher = &Bisection{}
 	}
 	if b.ls == nil {
-		b.ls = &LinesearchHelper{}
+		b.ls = &LinesearchMethod{}
 	}
 	b.ls.Linesearcher = b.Linesearcher
 	b.ls.NextDirectioner = b

--- a/bfgs.go
+++ b/bfgs.go
@@ -18,9 +18,9 @@ import (
 // convergence when in proximity to a local minimum. It has memory cost that is
 // O(n^2) relative to the input dimension.
 type BFGS struct {
-	LinesearchMethod LinesearchMethod
+	Linesearch Linesearch
 
-	linesearch *Linesearch
+	ls *LinesearchHelper
 
 	x    []float64 // location of the last major iteration
 	grad []float64 // gradient at the last major iteration
@@ -43,20 +43,20 @@ type BFGS struct {
 // it implements Method
 
 func (b *BFGS) Init(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {
-	if b.LinesearchMethod == nil {
-		b.LinesearchMethod = &Bisection{}
+	if b.Linesearch == nil {
+		b.Linesearch = &Bisection{}
 	}
-	if b.linesearch == nil {
-		b.linesearch = &Linesearch{}
+	if b.ls == nil {
+		b.ls = &LinesearchHelper{}
 	}
-	b.linesearch.Method = b.LinesearchMethod
-	b.linesearch.NextDirectioner = b
+	b.ls.Linesearch = b.Linesearch
+	b.ls.NextDirectioner = b
 
-	return b.linesearch.Init(loc, xNext)
+	return b.ls.Init(loc, xNext)
 }
 
 func (b *BFGS) Iterate(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {
-	return b.linesearch.Iterate(loc, xNext)
+	return b.ls.Iterate(loc, xNext)
 }
 
 func (b *BFGS) InitDirection(loc *Location, dir []float64) (stepSize float64) {

--- a/bfgs.go
+++ b/bfgs.go
@@ -10,7 +10,7 @@ import (
 )
 
 // BFGS implements the Method interface to perform the Broyden–Fletcher–Goldfarb–Shanno
-// optimization method with the given linesearch method. If LinesearchMethod is nil,
+// optimization method with the given linesearch method. If Linesearcher is nil,
 // it will be set to a reasonable default.
 //
 // BFGS is a quasi-Newton method that performs successive rank-one updates to
@@ -18,7 +18,7 @@ import (
 // convergence when in proximity to a local minimum. It has memory cost that is
 // O(n^2) relative to the input dimension.
 type BFGS struct {
-	Linesearch Linesearch
+	Linesearcher Linesearcher
 
 	ls *LinesearchHelper
 
@@ -39,17 +39,14 @@ type BFGS struct {
 	first bool // Is it the first iteration (used to set the scale of the initial hessian)
 }
 
-// NOTE: This method exists so that it's easier to use a bfgs algorithm because
-// it implements Method
-
 func (b *BFGS) Init(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {
-	if b.Linesearch == nil {
-		b.Linesearch = &Bisection{}
+	if b.Linesearcher == nil {
+		b.Linesearcher = &Bisection{}
 	}
 	if b.ls == nil {
 		b.ls = &LinesearchHelper{}
 	}
-	b.ls.Linesearch = b.Linesearch
+	b.ls.Linesearcher = b.Linesearcher
 	b.ls.NextDirectioner = b
 
 	return b.ls.Init(loc, xNext)

--- a/bisection.go
+++ b/bisection.go
@@ -6,7 +6,7 @@ package optimize
 
 import "math"
 
-// Bisection is a LinesearchMethod that uses a bisection to find a point that
+// Bisection is a Linesearcher that uses a bisection to find a point that
 // satisfies the strong Wolfe conditions with the given gradient constant and
 // function constant of zero. If GradConst is zero, it will be set to a reasonable
 // value. Bisection will panic if GradConst is not between zero and one.

--- a/bisection.go
+++ b/bisection.go
@@ -27,11 +27,11 @@ type Bisection struct {
 }
 
 func (b *Bisection) Init(f, g float64, step float64) EvaluationType {
-	if g >= 0 {
-		panic("bisection: initial derivative is non-negative")
-	}
 	if step <= 0 {
 		panic("bisection: bad step size")
+	}
+	if g >= 0 {
+		panic("bisection: initial derivative is non-negative")
 	}
 
 	if b.GradConst == 0 {

--- a/bisection.go
+++ b/bisection.go
@@ -26,9 +26,9 @@ type Bisection struct {
 	maxGrad  float64
 }
 
-func (b *Bisection) Init(loc LinesearchLocation, step float64) EvaluationType {
-	if loc.Derivative >= 0 {
-		panic("bisection: init G non-negative")
+func (b *Bisection) Init(f, g float64, step float64) EvaluationType {
+	if g >= 0 {
+		panic("bisection: initial derivative is non-negative")
 	}
 	if step <= 0 {
 		panic("bisection: bad step size")
@@ -45,18 +45,18 @@ func (b *Bisection) Init(loc LinesearchLocation, step float64) EvaluationType {
 	b.maxStep = math.Inf(1)
 	b.currStep = step
 
-	b.initF = loc.F
-	b.minF = loc.F
+	b.initF = f
+	b.minF = f
 	b.maxF = math.NaN()
 
-	b.initGrad = loc.Derivative
-	b.minGrad = loc.Derivative
+	b.initGrad = g
+	b.minGrad = g
 	b.maxGrad = math.NaN()
 
 	return FuncEvaluation | GradEvaluation
 }
 
-func (b *Bisection) Finished(loc LinesearchLocation) bool {
+func (b *Bisection) Finished(f, g float64) bool {
 	// Don't finish the linesearch until a minimum is found that is better than
 	// the best point found so far. We want to end up in the lowest basin of
 	// attraction
@@ -67,15 +67,13 @@ func (b *Bisection) Finished(loc LinesearchLocation) bool {
 	if b.minF < minF {
 		minF = b.minF
 	}
-	if StrongWolfeConditionsMet(loc.F, loc.Derivative, minF, b.initGrad, b.currStep, 0, b.GradConst) {
+	if StrongWolfeConditionsMet(f, g, minF, b.initGrad, b.currStep, 0, b.GradConst) {
 		return true
 	}
 	return false
 }
 
-func (b *Bisection) Iterate(loc LinesearchLocation) (float64, EvaluationType, error) {
-	f := loc.F
-	g := loc.Derivative
+func (b *Bisection) Iterate(f, g float64) (float64, EvaluationType, error) {
 	// Deciding on the next step size
 	if math.IsInf(b.maxStep, 1) {
 		// Have not yet bounded the minimum

--- a/cg.go
+++ b/cg.go
@@ -53,9 +53,9 @@ type CGVariant interface {
 // gradient methods. Pacific Journal of Optimization, 2 (2006), pp. 35-58, and
 // references therein.
 type CG struct {
-	// LinesearchMethod must satisfy the strong Wolfe conditions at every
-	// iteration. If LinesearchMethod == nil, an appropriate default is chosen.
-	LinesearchMethod LinesearchMethod
+	// Linesearch must satisfy the strong Wolfe conditions at every iteration.
+	// If Linesearch == nil, an appropriate default is chosen.
+	Linesearch Linesearch
 	// Variant implements the particular CG formula for computing β_k.
 	// If Variant is nil, an appropriate default is chosen.
 	Variant CGVariant
@@ -84,7 +84,7 @@ type CG struct {
 	// CG will panic if AngleRestartThreshold is not in the interval [-1, 0].
 	AngleRestartThreshold float64
 
-	linesearch *Linesearch
+	ls *LinesearchHelper
 
 	restartAfter    int
 	iterFromRestart int
@@ -102,8 +102,8 @@ func (cg *CG) Init(loc *Location, xNext []float64) (EvaluationType, IterationTyp
 		panic("cg: AngleRestartThreshold not in [-1, 0]")
 	}
 
-	if cg.LinesearchMethod == nil {
-		cg.LinesearchMethod = &Bisection{GradConst: 0.1}
+	if cg.Linesearch == nil {
+		cg.Linesearch = &Bisection{GradConst: 0.1}
 	}
 	if cg.Variant == nil {
 		cg.Variant = &HestenesStiefel{}
@@ -119,17 +119,17 @@ func (cg *CG) Init(loc *Location, xNext []float64) (EvaluationType, IterationTyp
 		cg.AngleRestartThreshold = angleRestartThreshold
 	}
 
-	if cg.linesearch == nil {
-		cg.linesearch = &Linesearch{}
+	if cg.ls == nil {
+		cg.ls = &LinesearchHelper{}
 	}
-	cg.linesearch.Method = cg.LinesearchMethod
-	cg.linesearch.NextDirectioner = cg
+	cg.ls.Linesearch = cg.Linesearch
+	cg.ls.NextDirectioner = cg
 
-	return cg.linesearch.Init(loc, xNext)
+	return cg.ls.Init(loc, xNext)
 }
 
 func (cg *CG) Iterate(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {
-	return cg.linesearch.Iterate(loc, xNext)
+	return cg.ls.Iterate(loc, xNext)
 }
 
 func (cg *CG) InitDirection(loc *Location, dir []float64) (stepSize float64) {

--- a/cg.go
+++ b/cg.go
@@ -53,9 +53,9 @@ type CGVariant interface {
 // gradient methods. Pacific Journal of Optimization, 2 (2006), pp. 35-58, and
 // references therein.
 type CG struct {
-	// Linesearch must satisfy the strong Wolfe conditions at every iteration.
-	// If Linesearch == nil, an appropriate default is chosen.
-	Linesearch Linesearch
+	// Linesearcher must satisfy the strong Wolfe conditions at every iteration.
+	// If Linesearcher == nil, an appropriate default is chosen.
+	Linesearcher Linesearcher
 	// Variant implements the particular CG formula for computing β_k.
 	// If Variant is nil, an appropriate default is chosen.
 	Variant CGVariant
@@ -102,8 +102,8 @@ func (cg *CG) Init(loc *Location, xNext []float64) (EvaluationType, IterationTyp
 		panic("cg: AngleRestartThreshold not in [-1, 0]")
 	}
 
-	if cg.Linesearch == nil {
-		cg.Linesearch = &Bisection{GradConst: 0.1}
+	if cg.Linesearcher == nil {
+		cg.Linesearcher = &Bisection{GradConst: 0.1}
 	}
 	if cg.Variant == nil {
 		cg.Variant = &HestenesStiefel{}
@@ -122,7 +122,7 @@ func (cg *CG) Init(loc *Location, xNext []float64) (EvaluationType, IterationTyp
 	if cg.ls == nil {
 		cg.ls = &LinesearchHelper{}
 	}
-	cg.ls.Linesearch = cg.Linesearch
+	cg.ls.Linesearcher = cg.Linesearcher
 	cg.ls.NextDirectioner = cg
 
 	return cg.ls.Init(loc, xNext)

--- a/cg.go
+++ b/cg.go
@@ -84,7 +84,7 @@ type CG struct {
 	// CG will panic if AngleRestartThreshold is not in the interval [-1, 0].
 	AngleRestartThreshold float64
 
-	ls *LinesearchHelper
+	ls *LinesearchMethod
 
 	restartAfter    int
 	iterFromRestart int
@@ -120,7 +120,7 @@ func (cg *CG) Init(loc *Location, xNext []float64) (EvaluationType, IterationTyp
 	}
 
 	if cg.ls == nil {
-		cg.ls = &LinesearchHelper{}
+		cg.ls = &LinesearchMethod{}
 	}
 	cg.ls.Linesearcher = cg.Linesearcher
 	cg.ls.NextDirectioner = cg

--- a/gradientdescent.go
+++ b/gradientdescent.go
@@ -6,36 +6,36 @@ package optimize
 
 import "github.com/gonum/floats"
 
-// GradientDescent is a Method that performs gradient-based optimization. Gradient
-// Descent performs successive steps along the direction of the gradient. The
-// LinesearchMethod specifies the kind of linesearch to be done, and StepSizer determines
-// the initial step size of each direction. If either LinesearchMethod or StepSizer
-// are nil, a reasonable value will be chosen.
+// GradientDescent is a Method that performs gradient-based optimization.
+// Gradient Descent performs successive steps along the direction of the
+// gradient. The Linesearch specifies the kind of linesearch to be done, and
+// StepSizer determines the initial step size of each direction. If either
+// Linesearch or StepSizer are nil, a reasonable value will be chosen.
 type GradientDescent struct {
-	LinesearchMethod LinesearchMethod
-	StepSizer        StepSizer
+	Linesearch Linesearch
+	StepSizer  StepSizer
 
-	linesearch *Linesearch
+	ls *LinesearchHelper
 }
 
 func (g *GradientDescent) Init(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {
 	if g.StepSizer == nil {
 		g.StepSizer = &QuadraticStepSize{}
 	}
-	if g.LinesearchMethod == nil {
-		g.LinesearchMethod = &Backtracking{}
+	if g.Linesearch == nil {
+		g.Linesearch = &Backtracking{}
 	}
-	if g.linesearch == nil {
-		g.linesearch = &Linesearch{}
+	if g.ls == nil {
+		g.ls = &LinesearchHelper{}
 	}
-	g.linesearch.Method = g.LinesearchMethod
-	g.linesearch.NextDirectioner = g
+	g.ls.Linesearch = g.Linesearch
+	g.ls.NextDirectioner = g
 
-	return g.linesearch.Init(loc, xNext)
+	return g.ls.Init(loc, xNext)
 }
 
 func (g *GradientDescent) Iterate(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {
-	return g.linesearch.Iterate(loc, xNext)
+	return g.ls.Iterate(loc, xNext)
 }
 
 func (g *GradientDescent) InitDirection(loc *Location, dir []float64) (stepSize float64) {

--- a/gradientdescent.go
+++ b/gradientdescent.go
@@ -8,12 +8,12 @@ import "github.com/gonum/floats"
 
 // GradientDescent is a Method that performs gradient-based optimization.
 // Gradient Descent performs successive steps along the direction of the
-// gradient. The Linesearch specifies the kind of linesearch to be done, and
+// gradient. The Linesearcher specifies the kind of linesearch to be done, and
 // StepSizer determines the initial step size of each direction. If either
-// Linesearch or StepSizer are nil, a reasonable value will be chosen.
+// Linesearcher or StepSizer are nil, a reasonable value will be chosen.
 type GradientDescent struct {
-	Linesearch Linesearch
-	StepSizer  StepSizer
+	Linesearcher Linesearcher
+	StepSizer    StepSizer
 
 	ls *LinesearchHelper
 }
@@ -22,13 +22,13 @@ func (g *GradientDescent) Init(loc *Location, xNext []float64) (EvaluationType, 
 	if g.StepSizer == nil {
 		g.StepSizer = &QuadraticStepSize{}
 	}
-	if g.Linesearch == nil {
-		g.Linesearch = &Backtracking{}
+	if g.Linesearcher == nil {
+		g.Linesearcher = &Backtracking{}
 	}
 	if g.ls == nil {
 		g.ls = &LinesearchHelper{}
 	}
-	g.ls.Linesearch = g.Linesearch
+	g.ls.Linesearcher = g.Linesearcher
 	g.ls.NextDirectioner = g
 
 	return g.ls.Init(loc, xNext)

--- a/gradientdescent.go
+++ b/gradientdescent.go
@@ -15,7 +15,7 @@ type GradientDescent struct {
 	Linesearcher Linesearcher
 	StepSizer    StepSizer
 
-	ls *LinesearchHelper
+	ls *LinesearchMethod
 }
 
 func (g *GradientDescent) Init(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {
@@ -26,7 +26,7 @@ func (g *GradientDescent) Init(loc *Location, xNext []float64) (EvaluationType, 
 		g.Linesearcher = &Backtracking{}
 	}
 	if g.ls == nil {
-		g.ls = &LinesearchHelper{}
+		g.ls = &LinesearchMethod{}
 	}
 	g.ls.Linesearcher = g.Linesearcher
 	g.ls.NextDirectioner = g

--- a/interfaces.go
+++ b/interfaces.go
@@ -4,28 +4,54 @@
 
 package optimize
 
-// Linesearch is a type that can perform a line search. Typically, these
-// methods will not be called by the user directly, as they will be called by
-// a LinesearchHelper struct.
+// A Method can optimize an objective function.
+type Method interface {
+	// Init initializes the method and stores the first location to evaluate
+	// in xNext.
+	Init(loc *Location, xNext []float64) (EvaluationType, IterationType, error)
+
+	// Iterate performs one iteration of the method and stores the next
+	// location to evaluate in xNext.
+	Iterate(loc *Location, xNext []float64) (EvaluationType, IterationType, error)
+
+	// Needs specifies information about the objective function needed by the
+	// optimizer beyond just the function value. The information is used
+	// internally for initialization and must match evaluation types returned
+	// by Init() and Iterate() during the optimization process.
+	Needs() struct {
+		Gradient bool
+		Hessian  bool
+	}
+}
+
+// Linesearch is a type that can perform a line search. It tries to find an
+// (approximate) minimum of the objective function along the search direction
+// dir_k starting at the most recent location x_k, i.e., it tries to minimize a
+// function
+//  φ(step) := f(x_k + step * dir_k), step > 0.
+// Typically, these methods will not be called by the user directly, as they
+// will be called by the LinesearchHelper struct.
 type Linesearch interface {
-	// Init initializes the linesearch method. LinesearchLocation contains the
-	// function information at step == 0, and step contains the first step length
-	// as specified by the NextDirectioner.
+	// Init initializes the linesearch method. Value and derivative contain
+	// φ(0) and φ'(0), respectively, and step contains the first trial step
+	// length as returned by the NextDirectioner.InitDirection(). It returns
+	// the type of evaluation to be performed at x_0 + step * dir_0.
 	Init(value, derivative float64, step float64) EvaluationType
 
-	// Finished takes in the function result at the most recent linesearch location,
-	// and returns true if the line search has been concluded.
+	// Finished takes in the values of φ and φ' evaluated at the previous step,
+	// and returns whether a sufficiently accurate minimum of φ has been found.
 	Finished(value, derivative float64) bool
 
-	// Iterate takes in the function results
-	// from evaluating the function at the previous step, and returns the
-	// next step size and EvaluationType to evaluate.
+	// Iterate takes in the values of φ and φ' evaluated at the previous step
+	// and returns the next step size and the type of evaluation to be
+	// performed at x_k + step * dir_k.
 	Iterate(value, derivative float64) (step float64, e EvaluationType, err error)
 }
 
-// NextDirectioner implements a strategy for computing a new line search direction
-// at each major iteration. Typically, these methods will not be called by the user directly,
-// as they will be called by a Linesearch struct.
+// NextDirectioner implements a strategy for computing a new line search
+// direction at each major iteration. Typically, these methods will not be
+// called by the user directly, as they will be called by the LinesearchHelper
+// struct.
 type NextDirectioner interface {
 	// InitDirection initializes the NextDirectioner at the given starting location,
 	// putting the initial direction in place into dir, and returning the initial
@@ -37,24 +63,6 @@ type NextDirectioner interface {
 	// next search direction is put in place into dir, and the next step size
 	// is returned. NextDirection must not modify Location.
 	NextDirection(loc *Location, dir []float64) (step float64)
-}
-
-// A Method can optimize an objective function.
-type Method interface {
-	// Initializes the method and returns the first location to evaluate
-	Init(loc *Location, xNext []float64) (EvaluationType, IterationType, error)
-
-	// Stores the next location to evaluate in xNext
-	Iterate(loc *Location, xNext []float64) (EvaluationType, IterationType, error)
-
-	// Needs specifies information about the objective function needed by the
-	// optimizer beyond just the function value. The information is used
-	// internally for initialization and must match evaluation types returned
-	// by Init() and Iterate() during the optimization process.
-	Needs() struct {
-		Gradient bool
-		Hessian  bool
-	}
 }
 
 // StepSizer can set the next step size of the optimization given the last Location.

--- a/interfaces.go
+++ b/interfaces.go
@@ -24,14 +24,14 @@ type Method interface {
 	}
 }
 
-// Linesearch is a type that can perform a line search. It tries to find an
+// Linesearcher is a type that can perform a line search. It tries to find an
 // (approximate) minimum of the objective function along the search direction
 // dir_k starting at the most recent location x_k, i.e., it tries to minimize a
 // function
 //  φ(step) := f(x_k + step * dir_k), step > 0.
 // Typically, these methods will not be called by the user directly, as they
 // will be called by the LinesearchHelper struct.
-type Linesearch interface {
+type Linesearcher interface {
 	// Init initializes the linesearch method. Value and derivative contain
 	// φ(0) and φ'(0), respectively, and step contains the first trial step
 	// length as returned by the NextDirectioner.InitDirection(). It returns

--- a/interfaces.go
+++ b/interfaces.go
@@ -4,10 +4,10 @@
 
 package optimize
 
-// LinesearchMethod is a type that can perform a line search. Typically, these
+// Linesearch is a type that can perform a line search. Typically, these
 // methods will not be called by the user directly, as they will be called by
-// a Linesearch struct.
-type LinesearchMethod interface {
+// a LinesearchHelper struct.
+type Linesearch interface {
 	// Init initializes the linesearch method. LinesearchLocation contains the
 	// function information at step == 0, and step contains the first step length
 	// as specified by the NextDirectioner.

--- a/interfaces.go
+++ b/interfaces.go
@@ -26,16 +26,16 @@ type Method interface {
 
 // Linesearcher is a type that can perform a line search. It tries to find an
 // (approximate) minimum of the objective function along the search direction
-// dir_k starting at the most recent location x_k, i.e., it tries to minimize a
-// function
-//  φ(step) := f(x_k + step * dir_k), step > 0.
-// Typically, these methods will not be called by the user directly, as they
-// will be called by the LinesearchMethod struct.
+// dir_k starting at the most recent location x_k, i.e., it tries to minimize
+// the function
+//  φ(step) := f(x_k + step * dir_k) where step > 0.
+// Typically, a Linesearcher will be used in conjuction with LinesearchMethod
+// for performing gradient-based optimization through sequential line searches.
 type Linesearcher interface {
 	// Init initializes the linesearch method. Value and derivative contain
 	// φ(0) and φ'(0), respectively, and step contains the first trial step
-	// length as returned by the NextDirectioner.InitDirection(). It returns
-	// the type of evaluation to be performed at x_0 + step * dir_0.
+	// length. It returns the type of evaluation to be performed at
+	// x_0 + step * dir_0.
 	Init(value, derivative float64, step float64) EvaluationType
 
 	// Finished takes in the values of φ and φ' evaluated at the previous step,
@@ -49,9 +49,9 @@ type Linesearcher interface {
 }
 
 // NextDirectioner implements a strategy for computing a new line search
-// direction at each major iteration. Typically, these methods will not be
-// called by the user directly, as they will be called by the LinesearchMethod
-// struct.
+// direction at each major iteration. Typically, a NextDirectioner will be
+// used in conjuction with LinesearchMethod for performing gradient-based
+// optimization through sequential line searches.
 type NextDirectioner interface {
 	// InitDirection initializes the NextDirectioner at the given starting location,
 	// putting the initial direction in place into dir, and returning the initial

--- a/interfaces.go
+++ b/interfaces.go
@@ -30,7 +30,7 @@ type Method interface {
 // function
 //  φ(step) := f(x_k + step * dir_k), step > 0.
 // Typically, these methods will not be called by the user directly, as they
-// will be called by the LinesearchHelper struct.
+// will be called by the LinesearchMethod struct.
 type Linesearcher interface {
 	// Init initializes the linesearch method. Value and derivative contain
 	// φ(0) and φ'(0), respectively, and step contains the first trial step
@@ -50,7 +50,7 @@ type Linesearcher interface {
 
 // NextDirectioner implements a strategy for computing a new line search
 // direction at each major iteration. Typically, these methods will not be
-// called by the user directly, as they will be called by the LinesearchHelper
+// called by the user directly, as they will be called by the LinesearchMethod
 // struct.
 type NextDirectioner interface {
 	// InitDirection initializes the NextDirectioner at the given starting location,

--- a/interfaces.go
+++ b/interfaces.go
@@ -11,16 +11,16 @@ type Linesearch interface {
 	// Init initializes the linesearch method. LinesearchLocation contains the
 	// function information at step == 0, and step contains the first step length
 	// as specified by the NextDirectioner.
-	Init(loc LinesearchLocation, step float64) EvaluationType
+	Init(value, derivative float64, step float64) EvaluationType
 
 	// Finished takes in the function result at the most recent linesearch location,
 	// and returns true if the line search has been concluded.
-	Finished(loc LinesearchLocation) bool
+	Finished(value, derivative float64) bool
 
 	// Iterate takes in the function results
 	// from evaluating the function at the previous step, and returns the
 	// next step size and EvaluationType to evaluate.
-	Iterate(loc LinesearchLocation) (step float64, e EvaluationType, err error)
+	Iterate(value, derivative float64) (step float64, e EvaluationType, err error)
 }
 
 // NextDirectioner implements a strategy for computing a new line search direction

--- a/lbfgs.go
+++ b/lbfgs.go
@@ -14,13 +14,13 @@ import (
 // better than BFGS for functions with Hessians that vary rapidly spatially.
 //
 // If Store is 0, Store is defaulted to 15.
-// A LinesearchMethod for LBFGS must satisfy the strong Wolfe conditions at every
-// iteration. If LinesearchMethod == nil, an appropriate default is chosen.
+// A Linesearch for LBFGS must satisfy the strong Wolfe conditions at every
+// iteration. If Linesearch == nil, an appropriate default is chosen.
 type LBFGS struct {
-	LinesearchMethod LinesearchMethod
-	Store            int // how many past iterations to store
+	Linesearch Linesearch
+	Store      int // how many past iterations to store
 
-	linesearch *Linesearch
+	ls *LinesearchHelper
 
 	dim    int
 	oldest int // element of the history slices that is the oldest
@@ -39,19 +39,19 @@ type LBFGS struct {
 }
 
 func (l *LBFGS) Init(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {
-	if l.LinesearchMethod == nil {
-		l.LinesearchMethod = &Bisection{}
+	if l.Linesearch == nil {
+		l.Linesearch = &Bisection{}
 	}
-	if l.linesearch == nil {
-		l.linesearch = &Linesearch{}
+	if l.ls == nil {
+		l.ls = &LinesearchHelper{}
 	}
-	l.linesearch.Method = l.LinesearchMethod
-	l.linesearch.NextDirectioner = l
-	return l.linesearch.Init(loc, xNext)
+	l.ls.Linesearch = l.Linesearch
+	l.ls.NextDirectioner = l
+	return l.ls.Init(loc, xNext)
 }
 
 func (l *LBFGS) Iterate(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {
-	return l.linesearch.Iterate(loc, xNext)
+	return l.ls.Iterate(loc, xNext)
 }
 
 func (l *LBFGS) InitDirection(loc *Location, dir []float64) (stepSize float64) {

--- a/lbfgs.go
+++ b/lbfgs.go
@@ -14,11 +14,11 @@ import (
 // better than BFGS for functions with Hessians that vary rapidly spatially.
 //
 // If Store is 0, Store is defaulted to 15.
-// A Linesearch for LBFGS must satisfy the strong Wolfe conditions at every
-// iteration. If Linesearch == nil, an appropriate default is chosen.
+// A Linesearcher for LBFGS must satisfy the strong Wolfe conditions at every
+// iteration. If Linesearcher == nil, an appropriate default is chosen.
 type LBFGS struct {
-	Linesearch Linesearch
-	Store      int // how many past iterations to store
+	Linesearcher Linesearcher
+	Store        int // how many past iterations to store
 
 	ls *LinesearchHelper
 
@@ -39,13 +39,13 @@ type LBFGS struct {
 }
 
 func (l *LBFGS) Init(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {
-	if l.Linesearch == nil {
-		l.Linesearch = &Bisection{}
+	if l.Linesearcher == nil {
+		l.Linesearcher = &Bisection{}
 	}
 	if l.ls == nil {
 		l.ls = &LinesearchHelper{}
 	}
-	l.ls.Linesearch = l.Linesearch
+	l.ls.Linesearcher = l.Linesearcher
 	l.ls.NextDirectioner = l
 	return l.ls.Init(loc, xNext)
 }

--- a/lbfgs.go
+++ b/lbfgs.go
@@ -20,7 +20,7 @@ type LBFGS struct {
 	Linesearcher Linesearcher
 	Store        int // how many past iterations to store
 
-	ls *LinesearchHelper
+	ls *LinesearchMethod
 
 	dim    int
 	oldest int // element of the history slices that is the oldest
@@ -43,7 +43,7 @@ func (l *LBFGS) Init(loc *Location, xNext []float64) (EvaluationType, IterationT
 		l.Linesearcher = &Bisection{}
 	}
 	if l.ls == nil {
-		l.ls = &LinesearchHelper{}
+		l.ls = &LinesearchMethod{}
 	}
 	l.ls.Linesearcher = l.Linesearcher
 	l.ls.NextDirectioner = l

--- a/linesearch.go
+++ b/linesearch.go
@@ -131,9 +131,9 @@ func (ls *LinesearchHelper) initNextLinesearch(loc *Location, xNext []float64) (
 // has been met. Under normal conditions, the following should be true, though this is not enforced:
 //  - initGrad < 0
 //  - step > 0
-//  - 0 < funConst < 1
-func ArmijoConditionMet(currObj, initObj, initGrad, step, funConst float64) bool {
-	return currObj <= initObj+funConst*step*initGrad
+//  - 0 < funcConst < 1
+func ArmijoConditionMet(currObj, initObj, initGrad, step, funcConst float64) bool {
+	return currObj <= initObj+funcConst*step*initGrad
 }
 
 // StrongWolfeConditionsMet returns true if the strong Wolfe conditions have been met.
@@ -142,9 +142,9 @@ func ArmijoConditionMet(currObj, initObj, initGrad, step, funConst float64) bool
 // conditions, the following should be true, though this is not enforced:
 //  - initGrad < 0
 //  - step > 0
-//  - 0 <= funConst < gradConst < 1
-func StrongWolfeConditionsMet(currObj, currGrad, initObj, initGrad, step, funConst, gradConst float64) bool {
-	if currObj > initObj+funConst*step*initGrad {
+//  - 0 <= funcConst < gradConst < 1
+func StrongWolfeConditionsMet(currObj, currGrad, initObj, initGrad, step, funcConst, gradConst float64) bool {
+	if currObj > initObj+funcConst*step*initGrad {
 		return false
 	}
 	return math.Abs(currGrad) < gradConst*math.Abs(initGrad)
@@ -156,9 +156,9 @@ func StrongWolfeConditionsMet(currObj, currGrad, initObj, initGrad, step, funCon
 // conditions, the following should be true, though this is not enforced:
 //  - initGrad < 0
 //  - step > 0
-//  - 0 <= funConst < gradConst < 1
-func WeakWolfeConditionsMet(currObj, currGrad, initObj, initGrad, step, funConst, gradConst float64) bool {
-	if currObj > initObj+funConst*step*initGrad {
+//  - 0 <= funcConst < gradConst < 1
+func WeakWolfeConditionsMet(currObj, currGrad, initObj, initGrad, step, funcConst, gradConst float64) bool {
+	if currObj > initObj+funcConst*step*initGrad {
 		return false
 	}
 	return currGrad >= gradConst*initGrad

--- a/linesearch.go
+++ b/linesearch.go
@@ -10,12 +10,13 @@ import (
 	"github.com/gonum/floats"
 )
 
-// LinesearchHelper encapsulates the common functionality of gradient-based
-// line-search optimization methods and serves as a helper struct for their
-// implementation. It consists of a NextDirectioner, which specifies the search
-// direction at each iteration, and a Linesearcher which performs a linesearch
-// along the search direction.
-type LinesearchHelper struct {
+// LinesearchMethod encapsulates the common functionality of gradient-based
+// line-search methods and can serve as a helper struct for their
+// implementation. It does not implement the Method interface because of the
+// missing Needs() method. It consists of a NextDirectioner, which specifies
+// the search direction at each iteration, and a Linesearcher which performs a
+// linesearch along the search direction.
+type LinesearchMethod struct {
 	NextDirectioner NextDirectioner
 	Linesearcher    Linesearcher
 
@@ -27,7 +28,7 @@ type LinesearchHelper struct {
 	iterType IterationType
 }
 
-func (ls *LinesearchHelper) Init(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {
+func (ls *LinesearchMethod) Init(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {
 	if loc.Gradient == nil {
 		panic("linesearch: gradient is nil")
 	}
@@ -40,7 +41,7 @@ func (ls *LinesearchHelper) Init(loc *Location, xNext []float64) (EvaluationType
 	return ls.initNextLinesearch(loc, xNext)
 }
 
-func (ls *LinesearchHelper) Iterate(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {
+func (ls *LinesearchMethod) Iterate(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {
 	if ls.iterType == SubIteration {
 		// We needed to evaluate invalid fields of Location. Now we have them
 		// and can announce MajorIteration.
@@ -94,7 +95,7 @@ func (ls *LinesearchHelper) Iterate(loc *Location, xNext []float64) (EvaluationT
 	return ls.evalType, ls.iterType, nil
 }
 
-func (ls *LinesearchHelper) initNextLinesearch(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {
+func (ls *LinesearchMethod) initNextLinesearch(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {
 	copy(ls.x, loc.X)
 
 	var stepSize float64

--- a/linesearch.go
+++ b/linesearch.go
@@ -58,11 +58,7 @@ func (ls *LinesearchHelper) Iterate(loc *Location, xNext []float64) (EvaluationT
 	}
 
 	projGrad := floats.Dot(loc.Gradient, ls.dir)
-	lsLoc := LinesearchLocation{
-		F:          loc.F,
-		Derivative: projGrad,
-	}
-	if ls.Linesearch.Finished(lsLoc) {
+	if ls.Linesearch.Finished(loc.F, projGrad) {
 		copy(xNext, loc.X)
 		// Check if the last evaluation evaluated all fields of Location.
 		ls.evalType = complementEval(loc, ls.evalType)
@@ -77,7 +73,7 @@ func (ls *LinesearchHelper) Iterate(loc *Location, xNext []float64) (EvaluationT
 	}
 
 	// Line search not done, just iterate.
-	stepSize, evalType, err := ls.Linesearch.Iterate(lsLoc)
+	stepSize, evalType, err := ls.Linesearch.Iterate(loc.F, projGrad)
 	if err != nil {
 		ls.evalType = NoEvaluation
 		ls.iterType = NoIteration
@@ -116,11 +112,7 @@ func (ls *LinesearchHelper) initNextLinesearch(loc *Location, xNext []float64) (
 		return ls.evalType, ls.iterType, ErrNonNegativeStepDirection
 	}
 
-	lsLoc := LinesearchLocation{
-		F:          loc.F,
-		Derivative: projGrad,
-	}
-	ls.evalType = ls.Linesearch.Init(lsLoc, stepSize)
+	ls.evalType = ls.Linesearch.Init(loc.F, projGrad, stepSize)
 
 	floats.AddScaledTo(xNext, ls.x, stepSize, ls.dir)
 	// Compare the starting point for the current iteration with the next

--- a/linesearch.go
+++ b/linesearch.go
@@ -10,12 +10,11 @@ import (
 	"github.com/gonum/floats"
 )
 
-// LinesearchMethod encapsulates the common functionality of gradient-based
-// line-search methods and can serve as a helper struct for their
-// implementation. It does not implement the Method interface because of the
-// missing Needs() method. It consists of a NextDirectioner, which specifies
-// the search direction at each iteration, and a Linesearcher which performs a
-// linesearch along the search direction.
+// LinesearchMethod represents an abstract optimization method in which
+// a function is optimized through successive line search optimizations.
+// It consists of a NextDirectioner, which specifies the search direction
+// of each linesearch, and a Linesearcher which performs a linesearch along
+// the search direction.
 type LinesearchMethod struct {
 	NextDirectioner NextDirectioner
 	Linesearcher    Linesearcher
@@ -128,8 +127,9 @@ func (ls *LinesearchMethod) initNextLinesearch(loc *Location, xNext []float64) (
 	return ls.evalType, ls.iterType, nil
 }
 
-// ArmijoConditionMet returns true if the Armijo condition (aka sufficient decrease)
-// has been met. Under normal conditions, the following should be true, though this is not enforced:
+// ArmijoConditionMet returns true if the Armijo condition (aka sufficient
+// decrease) has been met. Under normal conditions, the following should be
+// true, though this is not enforced:
 //  - initGrad < 0
 //  - step > 0
 //  - 0 < funcConst < 1
@@ -138,9 +138,10 @@ func ArmijoConditionMet(currObj, initObj, initGrad, step, funcConst float64) boo
 }
 
 // StrongWolfeConditionsMet returns true if the strong Wolfe conditions have been met.
-// The strong wolfe conditions ensure sufficient decrease in the function value,
-// and sufficient decrease in the magnitude of the projected gradient. Under normal
-// conditions, the following should be true, though this is not enforced:
+// The strong Wolfe conditions ensure sufficient decrease in the function
+// value, and sufficient decrease in the magnitude of the projected gradient.
+// Under normal conditions, the following should be true, though this is not
+// enforced:
 //  - initGrad < 0
 //  - step > 0
 //  - 0 <= funcConst < gradConst < 1
@@ -152,7 +153,7 @@ func StrongWolfeConditionsMet(currObj, currGrad, initObj, initGrad, step, funcCo
 }
 
 // WeakWolfeConditionsMet returns true if the weak Wolfe conditions have been met.
-// The weak wolfe conditions ensure sufficient decrease in the function value,
+// The weak Wolfe conditions ensure sufficient decrease in the function value,
 // and sufficient decrease in the value of the projected gradient. Under normal
 // conditions, the following should be true, though this is not enforced:
 //  - initGrad < 0

--- a/linesearch.go
+++ b/linesearch.go
@@ -13,11 +13,11 @@ import (
 // LinesearchHelper encapsulates the common functionality of gradient-based
 // line-search optimization methods and serves as a helper struct for their
 // implementation. It consists of a NextDirectioner, which specifies the search
-// direction at each iteration, and a Linesearch which performs a linesearch
+// direction at each iteration, and a Linesearcher which performs a linesearch
 // along the search direction.
 type LinesearchHelper struct {
 	NextDirectioner NextDirectioner
-	Linesearch      Linesearch
+	Linesearcher    Linesearcher
 
 	x     []float64 // Starting point for the current iteration.
 	dir   []float64 // Search direction for the current iteration.
@@ -58,7 +58,7 @@ func (ls *LinesearchHelper) Iterate(loc *Location, xNext []float64) (EvaluationT
 	}
 
 	projGrad := floats.Dot(loc.Gradient, ls.dir)
-	if ls.Linesearch.Finished(loc.F, projGrad) {
+	if ls.Linesearcher.Finished(loc.F, projGrad) {
 		copy(xNext, loc.X)
 		// Check if the last evaluation evaluated all fields of Location.
 		ls.evalType = complementEval(loc, ls.evalType)
@@ -73,7 +73,7 @@ func (ls *LinesearchHelper) Iterate(loc *Location, xNext []float64) (EvaluationT
 	}
 
 	// Line search not done, just iterate.
-	stepSize, evalType, err := ls.Linesearch.Iterate(loc.F, projGrad)
+	stepSize, evalType, err := ls.Linesearcher.Iterate(loc.F, projGrad)
 	if err != nil {
 		ls.evalType = NoEvaluation
 		ls.iterType = NoIteration
@@ -112,7 +112,7 @@ func (ls *LinesearchHelper) initNextLinesearch(loc *Location, xNext []float64) (
 		return ls.evalType, ls.iterType, ErrNonNegativeStepDirection
 	}
 
-	ls.evalType = ls.Linesearch.Init(loc.F, projGrad, stepSize)
+	ls.evalType = ls.Linesearcher.Init(loc.F, projGrad, stepSize)
 
 	floats.AddScaledTo(xNext, ls.x, stepSize, ls.dir)
 	// Compare the starting point for the current iteration with the next

--- a/newton.go
+++ b/newton.go
@@ -47,7 +47,7 @@ type Newton struct {
 	// Increase must be greater than 1. If Increase is 0, it is defaulted to 5.
 	Increase float64
 
-	ls *LinesearchHelper
+	ls *LinesearchMethod
 
 	hess *mat64.SymDense // Storage for a copy of the Hessian matrix.
 	chol *mat64.TriDense // Storage for the Cholesky factorization.
@@ -65,7 +65,7 @@ func (n *Newton) Init(loc *Location, xNext []float64) (EvaluationType, Iteration
 		n.Linesearcher = &Bisection{}
 	}
 	if n.ls == nil {
-		n.ls = &LinesearchHelper{}
+		n.ls = &LinesearchMethod{}
 	}
 	n.ls.Linesearcher = n.Linesearcher
 	n.ls.NextDirectioner = n

--- a/newton.go
+++ b/newton.go
@@ -35,11 +35,11 @@ const maxNewtonModifications = 20
 // cost of its factorization is prohibitive, BFGS or L-BFGS quasi-Newton method
 // can be used instead.
 type Newton struct {
-	// LinesearchMethod is a method used for selecting suitable steps along the
+	// Linesearch is a method used for selecting suitable steps along the
 	// descent direction d. Steps should satisfy at least one of the Wolfe,
-	// Goldstein or Armijo conditions. If LinesearchMethod == nil, an
-	// appropriate default is chosen.
-	LinesearchMethod LinesearchMethod
+	// Goldstein or Armijo conditions.
+	// If Linesearch == nil, an appropriate default is chosen.
+	Linesearch Linesearch
 	// Increase is the factor by which a scalar tau is successively increased
 	// so that (H + tau*I) is positive definite. Larger values reduce the
 	// number of trial Hessian factorizations, but also reduce the second-order
@@ -47,7 +47,7 @@ type Newton struct {
 	// Increase must be greater than 1. If Increase is 0, it is defaulted to 5.
 	Increase float64
 
-	linesearch *Linesearch
+	ls *LinesearchHelper
 
 	hess *mat64.SymDense // Storage for a copy of the Hessian matrix.
 	chol *mat64.TriDense // Storage for the Cholesky factorization.
@@ -61,20 +61,20 @@ func (n *Newton) Init(loc *Location, xNext []float64) (EvaluationType, Iteration
 	if n.Increase <= 1 {
 		panic("optimize: Newton.Increase must be greater than 1")
 	}
-	if n.LinesearchMethod == nil {
-		n.LinesearchMethod = &Bisection{}
+	if n.Linesearch == nil {
+		n.Linesearch = &Bisection{}
 	}
-	if n.linesearch == nil {
-		n.linesearch = &Linesearch{}
+	if n.ls == nil {
+		n.ls = &LinesearchHelper{}
 	}
-	n.linesearch.Method = n.LinesearchMethod
-	n.linesearch.NextDirectioner = n
+	n.ls.Linesearch = n.Linesearch
+	n.ls.NextDirectioner = n
 
-	return n.linesearch.Init(loc, xNext)
+	return n.ls.Init(loc, xNext)
 }
 
 func (n *Newton) Iterate(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {
-	return n.linesearch.Iterate(loc, xNext)
+	return n.ls.Iterate(loc, xNext)
 }
 
 func (n *Newton) InitDirection(loc *Location, dir []float64) (stepSize float64) {

--- a/newton.go
+++ b/newton.go
@@ -35,11 +35,11 @@ const maxNewtonModifications = 20
 // cost of its factorization is prohibitive, BFGS or L-BFGS quasi-Newton method
 // can be used instead.
 type Newton struct {
-	// Linesearch is a method used for selecting suitable steps along the
-	// descent direction d. Steps should satisfy at least one of the Wolfe,
+	// Linesearcher is used for selecting suitable steps along the descent
+	// direction d. Accepted steps should satisfy at least one of the Wolfe,
 	// Goldstein or Armijo conditions.
-	// If Linesearch == nil, an appropriate default is chosen.
-	Linesearch Linesearch
+	// If Linesearcher == nil, an appropriate default is chosen.
+	Linesearcher Linesearcher
 	// Increase is the factor by which a scalar tau is successively increased
 	// so that (H + tau*I) is positive definite. Larger values reduce the
 	// number of trial Hessian factorizations, but also reduce the second-order
@@ -61,13 +61,13 @@ func (n *Newton) Init(loc *Location, xNext []float64) (EvaluationType, Iteration
 	if n.Increase <= 1 {
 		panic("optimize: Newton.Increase must be greater than 1")
 	}
-	if n.Linesearch == nil {
-		n.Linesearch = &Bisection{}
+	if n.Linesearcher == nil {
+		n.Linesearcher = &Bisection{}
 	}
 	if n.ls == nil {
 		n.ls = &LinesearchHelper{}
 	}
-	n.ls.Linesearch = n.Linesearch
+	n.ls.Linesearcher = n.Linesearcher
 	n.ls.NextDirectioner = n
 
 	return n.ls.Init(loc, xNext)

--- a/types.go
+++ b/types.go
@@ -73,12 +73,6 @@ type Location struct {
 	Hessian  *mat64.SymDense
 }
 
-// LinesearchLocation is a location for a linesearch subiteration
-type LinesearchLocation struct {
-	F          float64 // Function value at the step
-	Derivative float64 // Projected gradient in the linesearch direction
-}
-
 // Result represents the answer of an optimization run. It contains the optimum
 // location as well as the Status at convergence and Statistics taken during the
 // run.

--- a/unconstrained_test.go
+++ b/unconstrained_test.go
@@ -1015,7 +1015,7 @@ func TestGradientDescent(t *testing.T) {
 
 func TestGradientDescentBacktracking(t *testing.T) {
 	testLocal(t, gradientDescentTests, &GradientDescent{
-		Linesearch: &Backtracking{
+		Linesearcher: &Backtracking{
 			FunConst: 0.1,
 		},
 	})
@@ -1023,7 +1023,7 @@ func TestGradientDescentBacktracking(t *testing.T) {
 
 func TestGradientDescentBisection(t *testing.T) {
 	testLocal(t, gradientDescentTests, &GradientDescent{
-		Linesearch: &Bisection{},
+		Linesearcher: &Bisection{},
 	})
 }
 
@@ -1292,7 +1292,7 @@ func TestIssue76(t *testing.T) {
 		MajorIterations:   1000000,
 	}
 	m := &GradientDescent{
-		Linesearch: &Backtracking{},
+		Linesearcher: &Backtracking{},
 	}
 	// We are not interested in the error, only in the returned status.
 	r, _ := Local(p, x, s, m)

--- a/unconstrained_test.go
+++ b/unconstrained_test.go
@@ -1016,7 +1016,7 @@ func TestGradientDescent(t *testing.T) {
 func TestGradientDescentBacktracking(t *testing.T) {
 	testLocal(t, gradientDescentTests, &GradientDescent{
 		Linesearcher: &Backtracking{
-			FunConst: 0.1,
+			FuncConst: 0.1,
 		},
 	})
 }

--- a/unconstrained_test.go
+++ b/unconstrained_test.go
@@ -1015,7 +1015,7 @@ func TestGradientDescent(t *testing.T) {
 
 func TestGradientDescentBacktracking(t *testing.T) {
 	testLocal(t, gradientDescentTests, &GradientDescent{
-		LinesearchMethod: &Backtracking{
+		Linesearch: &Backtracking{
 			FunConst: 0.1,
 		},
 	})
@@ -1023,7 +1023,7 @@ func TestGradientDescentBacktracking(t *testing.T) {
 
 func TestGradientDescentBisection(t *testing.T) {
 	testLocal(t, gradientDescentTests, &GradientDescent{
-		LinesearchMethod: &Bisection{},
+		Linesearch: &Bisection{},
 	})
 }
 
@@ -1292,7 +1292,7 @@ func TestIssue76(t *testing.T) {
 		MajorIterations:   1000000,
 	}
 	m := &GradientDescent{
-		LinesearchMethod: &Backtracking{},
+		Linesearch: &Backtracking{},
 	}
 	// We are not interested in the error, only in the returned status.
 	r, _ := Local(p, x, s, m)


### PR DESCRIPTION
This is something I have wanted to do for some time now:

* `Linesearch.Init()` and `Linesearch.initNextLinesearch()` were both doing almost exactly the same thing. Now the former calls the latter.
* It is very unlikely that `Linesearch` could be used for a non-gradient-based optimization. Init() now panics, if `loc.Gradient == nil`, which makes the code simpler.
* Both `Linesearch.Iterate()` and `Linesearch.initNextLinesearch()` were slightly cleaned and improved, for example `evalType` and `iterType` are now both consistently updated.
* Docs for `Linesearch` were improved to make clear that it is just a helper struct, not a method in itself.
* I renamed `Linesearch` to `LinesearchHelper` and `LinesearchMethod` to `Linesearch`. As the commit message says:

> Linesearch is a too nice name to be used for only a helper struct.
LinesearchHelper better transmits its purpose and leaves the name
Linesearch free for what used to be LinesearchMethod. LinesearchMethod
was a bit confusing because Method is the interface for any optimization
method and so the name suggested a relation that was not there.

* I also renamed the related fields in GradientDescent, CG, BFGS, LBFGS and Newton to match the interface names. The previous situation was constantly distracting me.
* Removed `LinesearchLocation`

The diffs are dense, but there is nothing special going on except for many renames (mostly). The commits are better viewed separately.

@btracey , PTAL

~~There is one more thing that I would like to add to this PR to take it all with one strike. I don't like `LinesearchLocation` very much. The name is too long and the type's sole purpose is to pass two numbers to `Linesearch` (former `LinesearchMethod`). That can be done by passing the numbers directly as arguments. So if you agree with eliminating `LinesearchLocation` (the name is not very accurate anyway) @btracey , I would like to add this change too.~~