### PR TITLE
Merge IterationType and EvaluationType, simplify Method interface

### DIFF
--- a/backtracking.go
+++ b/backtracking.go
@@ -33,7 +33,7 @@ type Backtracking struct {
 	initG    float64
 }
 
-func (b *Backtracking) Init(f, g float64, step float64) EvaluationType {
+func (b *Backtracking) Init(f, g float64, step float64) RequestType {
 	if step <= 0 {
 		panic("backtracking: bad step size")
 	}
@@ -64,10 +64,10 @@ func (b *Backtracking) Finished(f, _ float64) bool {
 	return ArmijoConditionMet(f, b.initF, b.initG, b.stepSize, b.FuncConst)
 }
 
-func (b *Backtracking) Iterate(_, _ float64) (float64, EvaluationType, error) {
+func (b *Backtracking) Iterate(_, _ float64) (float64, RequestType, error) {
 	b.stepSize *= b.Decrease
 	if b.stepSize < minimumBacktrackingStepSize {
-		return 0, NoEvaluation, ErrLinesearchFailure
+		return 0, NoRequest, ErrLinesearchFailure
 	}
 	return b.stepSize, FuncEvaluation, nil
 }

--- a/backtracking.go
+++ b/backtracking.go
@@ -33,7 +33,7 @@ type Backtracking struct {
 	initG    float64
 }
 
-func (b *Backtracking) Init(f, g float64, step float64) RequestType {
+func (b *Backtracking) Init(f, g float64, step float64) Operation {
 	if step <= 0 {
 		panic("backtracking: bad step size")
 	}
@@ -64,10 +64,10 @@ func (b *Backtracking) Finished(f, _ float64) bool {
 	return ArmijoConditionMet(f, b.initF, b.initG, b.stepSize, b.FuncConst)
 }
 
-func (b *Backtracking) Iterate(_, _ float64) (float64, RequestType, error) {
+func (b *Backtracking) Iterate(_, _ float64) (float64, Operation, error) {
 	b.stepSize *= b.Decrease
 	if b.stepSize < minimumBacktrackingStepSize {
-		return 0, NoRequest, ErrLinesearchFailure
+		return 0, NoOperation, ErrLinesearchFailure
 	}
 	return b.stepSize, FuncEvaluation, nil
 }

--- a/bfgs.go
+++ b/bfgs.go
@@ -39,7 +39,7 @@ type BFGS struct {
 	first bool // Is it the first iteration (used to set the scale of the initial hessian)
 }
 
-func (b *BFGS) Init(loc *Location) (RequestType, error) {
+func (b *BFGS) Init(loc *Location) (Operation, error) {
 	if b.Linesearcher == nil {
 		b.Linesearcher = &Bisection{}
 	}
@@ -52,7 +52,7 @@ func (b *BFGS) Init(loc *Location) (RequestType, error) {
 	return b.ls.Init(loc)
 }
 
-func (b *BFGS) Iterate(loc *Location) (RequestType, error) {
+func (b *BFGS) Iterate(loc *Location) (Operation, error) {
 	return b.ls.Iterate(loc)
 }
 

--- a/bfgs.go
+++ b/bfgs.go
@@ -39,7 +39,7 @@ type BFGS struct {
 	first bool // Is it the first iteration (used to set the scale of the initial hessian)
 }
 
-func (b *BFGS) Init(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {
+func (b *BFGS) Init(loc *Location) (RequestType, error) {
 	if b.Linesearcher == nil {
 		b.Linesearcher = &Bisection{}
 	}
@@ -49,11 +49,11 @@ func (b *BFGS) Init(loc *Location, xNext []float64) (EvaluationType, IterationTy
 	b.ls.Linesearcher = b.Linesearcher
 	b.ls.NextDirectioner = b
 
-	return b.ls.Init(loc, xNext)
+	return b.ls.Init(loc)
 }
 
-func (b *BFGS) Iterate(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {
-	return b.ls.Iterate(loc, xNext)
+func (b *BFGS) Iterate(loc *Location) (RequestType, error) {
+	return b.ls.Iterate(loc)
 }
 
 func (b *BFGS) InitDirection(loc *Location, dir []float64) (stepSize float64) {

--- a/bisection.go
+++ b/bisection.go
@@ -26,7 +26,7 @@ type Bisection struct {
 	maxGrad  float64
 }
 
-func (b *Bisection) Init(f, g float64, step float64) EvaluationType {
+func (b *Bisection) Init(f, g float64, step float64) RequestType {
 	if step <= 0 {
 		panic("bisection: bad step size")
 	}
@@ -73,7 +73,7 @@ func (b *Bisection) Finished(f, g float64) bool {
 	return false
 }
 
-func (b *Bisection) Iterate(f, g float64) (float64, EvaluationType, error) {
+func (b *Bisection) Iterate(f, g float64) (float64, RequestType, error) {
 	// Deciding on the next step size
 	if math.IsInf(b.maxStep, 1) {
 		// Have not yet bounded the minimum
@@ -135,10 +135,10 @@ func (b *Bisection) Iterate(f, g float64) (float64, EvaluationType, error) {
 // both of which indicate the minimization must stop. If the steps are different,
 // it sets the new step size and returns the step and evaluation type. If the steps
 // are the same, it returns an error.
-func (b *Bisection) checkStepEqual(newStep float64, e EvaluationType) (float64, EvaluationType, error) {
+func (b *Bisection) checkStepEqual(newStep float64, r RequestType) (float64, RequestType, error) {
 	if b.currStep == newStep {
-		return b.currStep, NoEvaluation, ErrLinesearchFailure
+		return b.currStep, NoRequest, ErrLinesearchFailure
 	}
 	b.currStep = newStep
-	return newStep, e, nil
+	return newStep, r, nil
 }

--- a/bisection.go
+++ b/bisection.go
@@ -26,7 +26,7 @@ type Bisection struct {
 	maxGrad  float64
 }
 
-func (b *Bisection) Init(f, g float64, step float64) RequestType {
+func (b *Bisection) Init(f, g float64, step float64) Operation {
 	if step <= 0 {
 		panic("bisection: bad step size")
 	}
@@ -73,7 +73,7 @@ func (b *Bisection) Finished(f, g float64) bool {
 	return false
 }
 
-func (b *Bisection) Iterate(f, g float64) (float64, RequestType, error) {
+func (b *Bisection) Iterate(f, g float64) (float64, Operation, error) {
 	// Deciding on the next step size
 	if math.IsInf(b.maxStep, 1) {
 		// Have not yet bounded the minimum
@@ -135,10 +135,10 @@ func (b *Bisection) Iterate(f, g float64) (float64, RequestType, error) {
 // both of which indicate the minimization must stop. If the steps are different,
 // it sets the new step size and returns the step and evaluation type. If the steps
 // are the same, it returns an error.
-func (b *Bisection) checkStepEqual(newStep float64, r RequestType) (float64, RequestType, error) {
+func (b *Bisection) checkStepEqual(newStep float64, op Operation) (float64, Operation, error) {
 	if b.currStep == newStep {
-		return b.currStep, NoRequest, ErrLinesearchFailure
+		return b.currStep, NoOperation, ErrLinesearchFailure
 	}
 	b.currStep = newStep
-	return newStep, r, nil
+	return newStep, op, nil
 }

--- a/cg.go
+++ b/cg.go
@@ -94,7 +94,7 @@ type CG struct {
 	gradPrevNorm float64
 }
 
-func (cg *CG) Init(loc *Location) (RequestType, error) {
+func (cg *CG) Init(loc *Location) (Operation, error) {
 	if cg.IterationRestartFactor < 0 {
 		panic("cg: IterationRestartFactor is negative")
 	}
@@ -128,7 +128,7 @@ func (cg *CG) Init(loc *Location) (RequestType, error) {
 	return cg.ls.Init(loc)
 }
 
-func (cg *CG) Iterate(loc *Location) (RequestType, error) {
+func (cg *CG) Iterate(loc *Location) (Operation, error) {
 	return cg.ls.Iterate(loc)
 }
 

--- a/cg.go
+++ b/cg.go
@@ -94,7 +94,7 @@ type CG struct {
 	gradPrevNorm float64
 }
 
-func (cg *CG) Init(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {
+func (cg *CG) Init(loc *Location) (RequestType, error) {
 	if cg.IterationRestartFactor < 0 {
 		panic("cg: IterationRestartFactor is negative")
 	}
@@ -125,11 +125,11 @@ func (cg *CG) Init(loc *Location, xNext []float64) (EvaluationType, IterationTyp
 	cg.ls.Linesearcher = cg.Linesearcher
 	cg.ls.NextDirectioner = cg
 
-	return cg.ls.Init(loc, xNext)
+	return cg.ls.Init(loc)
 }
 
-func (cg *CG) Iterate(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {
-	return cg.ls.Iterate(loc, xNext)
+func (cg *CG) Iterate(loc *Location) (RequestType, error) {
+	return cg.ls.Iterate(loc)
 }
 
 func (cg *CG) InitDirection(loc *Location, dir []float64) (stepSize float64) {

--- a/gradientdescent.go
+++ b/gradientdescent.go
@@ -18,7 +18,7 @@ type GradientDescent struct {
 	ls *LinesearchMethod
 }
 
-func (g *GradientDescent) Init(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {
+func (g *GradientDescent) Init(loc *Location) (RequestType, error) {
 	if g.StepSizer == nil {
 		g.StepSizer = &QuadraticStepSize{}
 	}
@@ -31,11 +31,11 @@ func (g *GradientDescent) Init(loc *Location, xNext []float64) (EvaluationType, 
 	g.ls.Linesearcher = g.Linesearcher
 	g.ls.NextDirectioner = g
 
-	return g.ls.Init(loc, xNext)
+	return g.ls.Init(loc)
 }
 
-func (g *GradientDescent) Iterate(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {
-	return g.ls.Iterate(loc, xNext)
+func (g *GradientDescent) Iterate(loc *Location) (RequestType, error) {
+	return g.ls.Iterate(loc)
 }
 
 func (g *GradientDescent) InitDirection(loc *Location, dir []float64) (stepSize float64) {

--- a/gradientdescent.go
+++ b/gradientdescent.go
@@ -18,7 +18,7 @@ type GradientDescent struct {
 	ls *LinesearchMethod
 }
 
-func (g *GradientDescent) Init(loc *Location) (RequestType, error) {
+func (g *GradientDescent) Init(loc *Location) (Operation, error) {
 	if g.StepSizer == nil {
 		g.StepSizer = &QuadraticStepSize{}
 	}
@@ -34,7 +34,7 @@ func (g *GradientDescent) Init(loc *Location) (RequestType, error) {
 	return g.ls.Init(loc)
 }
 
-func (g *GradientDescent) Iterate(loc *Location) (RequestType, error) {
+func (g *GradientDescent) Iterate(loc *Location) (Operation, error) {
 	return g.ls.Iterate(loc)
 }
 

--- a/interfaces.go
+++ b/interfaces.go
@@ -30,15 +30,15 @@ package optimize
 // combine the Evaluation operations with the Iteration operations.
 type Method interface {
 	// Init initializes the method based on the initial data in loc, updates it
-	// and returns the first request.
+	// and returns the first operation to be carried out by the caller.
 	// The initial location must be valid as specified by Needs().
-	Init(loc *Location) (RequestType, error)
+	Init(loc *Location) (Operation, error)
 
 	// Iterate retrieves data from loc, performs one iteration of the method,
-	// updates loc and returns the next request.
+	// updates loc and returns the next operation.
 	// TODO(vladimir-ch): When decided, say something whether the contents of
 	// Location is preserved between calls to Iterate().
-	Iterate(loc *Location) (RequestType, error)
+	Iterate(loc *Location) (Operation, error)
 
 	// Needs specifies information about the objective function needed by the
 	// optimizer beyond just the function value. The information is used
@@ -69,7 +69,7 @@ type Linesearcher interface {
 	// φ(0) and φ'(0), respectively, and step contains the first trial step
 	// length. It returns the type of evaluation to be performed at
 	// x_0 + step * dir_0.
-	Init(value, derivative float64, step float64) RequestType
+	Init(value, derivative float64, step float64) Operation
 
 	// Finished takes in the values of φ and φ' evaluated at the previous step,
 	// and returns whether a sufficiently accurate minimum of φ has been found.
@@ -78,7 +78,7 @@ type Linesearcher interface {
 	// Iterate takes in the values of φ and φ' evaluated at the previous step
 	// and returns the next step size and the type of evaluation to be
 	// performed at x_k + step * dir_k.
-	Iterate(value, derivative float64) (step float64, r RequestType, err error)
+	Iterate(value, derivative float64) (step float64, op Operation, err error)
 }
 
 // NextDirectioner implements a strategy for computing a new line search
@@ -109,5 +109,5 @@ type StepSizer interface {
 // the progress to StdOut or to a log file. A Recorder must not modify any data.
 type Recorder interface {
 	Init() error
-	Record(*Location, RequestType, *Stats) error
+	Record(*Location, Operation, *Stats) error
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -8,11 +8,11 @@ package optimize
 type Method interface {
 	// Init initializes the method and stores the first location to evaluate
 	// in xNext.
-	Init(loc *Location, xNext []float64) (EvaluationType, IterationType, error)
+	Init(loc *Location) (RequestType, error)
 
 	// Iterate performs one iteration of the method and stores the next
 	// location to evaluate in xNext.
-	Iterate(loc *Location, xNext []float64) (EvaluationType, IterationType, error)
+	Iterate(loc *Location) (RequestType, error)
 
 	// Needs specifies information about the objective function needed by the
 	// optimizer beyond just the function value. The information is used
@@ -36,7 +36,7 @@ type Linesearcher interface {
 	// φ(0) and φ'(0), respectively, and step contains the first trial step
 	// length. It returns the type of evaluation to be performed at
 	// x_0 + step * dir_0.
-	Init(value, derivative float64, step float64) EvaluationType
+	Init(value, derivative float64, step float64) RequestType
 
 	// Finished takes in the values of φ and φ' evaluated at the previous step,
 	// and returns whether a sufficiently accurate minimum of φ has been found.
@@ -45,7 +45,7 @@ type Linesearcher interface {
 	// Iterate takes in the values of φ and φ' evaluated at the previous step
 	// and returns the next step size and the type of evaluation to be
 	// performed at x_k + step * dir_k.
-	Iterate(value, derivative float64) (step float64, e EvaluationType, err error)
+	Iterate(value, derivative float64) (step float64, r RequestType, err error)
 }
 
 // NextDirectioner implements a strategy for computing a new line search
@@ -84,5 +84,5 @@ type Statuser interface {
 // the progress to StdOut or to a log file. A Recorder must not modify any data.
 type Recorder interface {
 	Init() error
-	Record(*Location, EvaluationType, IterationType, *Stats) error
+	Record(*Location, RequestType, *Stats) error
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -13,7 +13,7 @@ package optimize
 // data and their representation, and enables automation of common operations
 // like checking for (various types of) convergence and maintaining statistics.
 //
-// A Method can command an Evaluation or a MajorIteration operation.
+// A Method can command an Evaluation, a MajorIteration or NoOperation operations.
 // An evaluation operation is one or more of the Evaluation operations
 // (FuncEvaluation, GradEvaluation, etc.) which can be combined with
 // the bitwise or operator. In an evaluation operation, the requested routines
@@ -25,8 +25,8 @@ package optimize
 // of the optimization (GradientThreshold, etc.) will be checked using this new
 // minimum.
 //
-// A Method must not return InitIteration and PostIteration requests. These are
-// reserved for the clients to be passed to Recorders. A method must also not
+// A Method must not return InitIteration and PostIteration operations. These are
+// reserved for the clients to be passed to Recorders. A Method must also not
 // combine the Evaluation operations with the Iteration operations.
 type Method interface {
 	// Init initializes the method based on the initial data in loc, updates it

--- a/lbfgs.go
+++ b/lbfgs.go
@@ -38,7 +38,7 @@ type LBFGS struct {
 	rhoHist []float64   // last Store iterations of rho
 }
 
-func (l *LBFGS) Init(loc *Location) (RequestType, error) {
+func (l *LBFGS) Init(loc *Location) (Operation, error) {
 	if l.Linesearcher == nil {
 		l.Linesearcher = &Bisection{}
 	}
@@ -50,7 +50,7 @@ func (l *LBFGS) Init(loc *Location) (RequestType, error) {
 	return l.ls.Init(loc)
 }
 
-func (l *LBFGS) Iterate(loc *Location) (RequestType, error) {
+func (l *LBFGS) Iterate(loc *Location) (Operation, error) {
 	return l.ls.Iterate(loc)
 }
 

--- a/lbfgs.go
+++ b/lbfgs.go
@@ -38,7 +38,7 @@ type LBFGS struct {
 	rhoHist []float64   // last Store iterations of rho
 }
 
-func (l *LBFGS) Init(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {
+func (l *LBFGS) Init(loc *Location) (RequestType, error) {
 	if l.Linesearcher == nil {
 		l.Linesearcher = &Bisection{}
 	}
@@ -47,11 +47,11 @@ func (l *LBFGS) Init(loc *Location, xNext []float64) (EvaluationType, IterationT
 	}
 	l.ls.Linesearcher = l.Linesearcher
 	l.ls.NextDirectioner = l
-	return l.ls.Init(loc, xNext)
+	return l.ls.Init(loc)
 }
 
-func (l *LBFGS) Iterate(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {
-	return l.ls.Iterate(loc, xNext)
+func (l *LBFGS) Iterate(loc *Location) (RequestType, error) {
+	return l.ls.Iterate(loc)
 }
 
 func (l *LBFGS) InitDirection(loc *Location, dir []float64) (stepSize float64) {

--- a/linesearch.go
+++ b/linesearch.go
@@ -64,8 +64,9 @@ func (ls *LinesearchMethod) Iterate(loc *Location) (Operation, error) {
 
 	case MajorIteration:
 		// We previously requested MajorIteration but since we're here, the
-		// previous location was not good enough to converge. So start the next
-		// linesearch and store the next evaluation point in loc.X.
+		// previous location was not good enough to converge the full
+		// optimization. Start the next linesearch and store the next
+		// evaluation point in loc.X.
 		return ls.initNextLinesearch(loc.X)
 
 	default:

--- a/linesearch.go
+++ b/linesearch.go
@@ -10,14 +10,13 @@ import (
 	"github.com/gonum/floats"
 )
 
-// LinesearchMethod represents an abstract optimization method in which
-// a function is optimized through successive line search optimizations.
-// It consists of a NextDirectioner, which specifies the search direction
-// of each linesearch, and a Linesearcher which performs a linesearch along
-// the search direction.
+// LinesearchMethod represents an abstract optimization method in which a
+// function is optimized through successive line search optimizations.
 type LinesearchMethod struct {
+	// NextDirectioner specifies the search direction of each linesearch.
 	NextDirectioner NextDirectioner
-	Linesearcher    Linesearcher
+	// Linesearcher performs a linesearch along the search direction.
+	Linesearcher Linesearcher
 
 	x   []float64 // Starting point for the current iteration.
 	dir []float64 // Search direction for the current iteration.

--- a/linesearch.go
+++ b/linesearch.go
@@ -118,7 +118,11 @@ func (ls *LinesearchMethod) Iterate(loc *Location) (Operation, error) {
 		panic("linesearch: Linesearcher returned invalid operation")
 	}
 
-	if step != ls.lastStep {
+	if step == ls.lastStep {
+		// Linesearcher is requesting another evaluation at the same point
+		// which is stored in ls.loc.X.
+		copy(loc.X, ls.loc.X)
+	} else {
 		// We are moving to a new location.
 
 		// Compute the next evaluation point and store it in loc.X.
@@ -133,10 +137,6 @@ func (ls *LinesearchMethod) Iterate(loc *Location) (Operation, error) {
 		ls.lastStep = step
 		copy(ls.loc.X, loc.X) // Move ls.loc to the next evaluation point
 		ls.eval = NoOperation // and invalidate all its fields.
-	} else {
-		// Linesearcher is requesting another evaluation at the same point
-		// which is stored in ls.loc.X.
-		copy(loc.X, ls.loc.X)
 	}
 
 	ls.lastOp = op

--- a/local.go
+++ b/local.go
@@ -169,7 +169,7 @@ func minimize(p *Problem, method Method, settings *Settings, stats *Stats, optLo
 			status = checkConvergence(optLoc, settings)
 
 		default: // Any of the Evaluation operations.
-			if !op.IsEvaluation() {
+			if !op.isEvaluation() {
 				panic(fmt.Sprintf("optimize: invalid evaluation %v", op))
 			}
 

--- a/neldermead.go
+++ b/neldermead.go
@@ -82,7 +82,7 @@ type NelderMead struct {
 	reflectedValue float64    // Value at the last reflection point
 }
 
-func (n *NelderMead) Init(loc *Location) (RequestType, error) {
+func (n *NelderMead) Init(loc *Location) (Operation, error) {
 	dim := len(loc.X)
 	if cap(n.vertices) < dim+1 {
 		n.vertices = make([][]float64, dim+1)
@@ -166,7 +166,7 @@ func computeCentroid(vertices [][]float64, centroid []float64) {
 	}
 }
 
-func (n *NelderMead) Iterate(loc *Location) (RequestType, error) {
+func (n *NelderMead) Iterate(loc *Location) (Operation, error) {
 	dim := len(loc.X)
 	switch n.lastIter {
 	case nmInitialize:
@@ -237,7 +237,7 @@ func (n *NelderMead) Iterate(loc *Location) (RequestType, error) {
 
 // returnNext updates the location based on the iteration type and the current
 // simplex, and returns the next request.
-func (n *NelderMead) returnNext(iter nmIterType, loc *Location) (RequestType, error) {
+func (n *NelderMead) returnNext(iter nmIterType, loc *Location) (Operation, error) {
 	n.lastIter = iter
 	switch iter {
 	case nmMajor:

--- a/newton.go
+++ b/newton.go
@@ -54,7 +54,7 @@ type Newton struct {
 	tau  float64
 }
 
-func (n *Newton) Init(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {
+func (n *Newton) Init(loc *Location) (RequestType, error) {
 	if n.Increase == 0 {
 		n.Increase = 5
 	}
@@ -70,11 +70,11 @@ func (n *Newton) Init(loc *Location, xNext []float64) (EvaluationType, Iteration
 	n.ls.Linesearcher = n.Linesearcher
 	n.ls.NextDirectioner = n
 
-	return n.ls.Init(loc, xNext)
+	return n.ls.Init(loc)
 }
 
-func (n *Newton) Iterate(loc *Location, xNext []float64) (EvaluationType, IterationType, error) {
-	return n.ls.Iterate(loc, xNext)
+func (n *Newton) Iterate(loc *Location) (RequestType, error) {
+	return n.ls.Iterate(loc)
 }
 
 func (n *Newton) InitDirection(loc *Location, dir []float64) (stepSize float64) {

--- a/newton.go
+++ b/newton.go
@@ -54,7 +54,7 @@ type Newton struct {
 	tau  float64
 }
 
-func (n *Newton) Init(loc *Location) (RequestType, error) {
+func (n *Newton) Init(loc *Location) (Operation, error) {
 	if n.Increase == 0 {
 		n.Increase = 5
 	}
@@ -73,7 +73,7 @@ func (n *Newton) Init(loc *Location) (RequestType, error) {
 	return n.ls.Init(loc)
 }
 
-func (n *Newton) Iterate(loc *Location) (RequestType, error) {
+func (n *Newton) Iterate(loc *Location) (Operation, error) {
 	return n.ls.Iterate(loc)
 }
 

--- a/printer.go
+++ b/printer.go
@@ -55,20 +55,20 @@ func (p *Printer) Init() error {
 	return nil
 }
 
-func (p *Printer) Record(loc *Location, r RequestType, stats *Stats) error {
-	if r != MajorIteration && r != InitIteration && r != PostIteration {
+func (p *Printer) Record(loc *Location, op Operation, stats *Stats) error {
+	if op != MajorIteration && op != InitIteration && op != PostIteration {
 		return nil
 	}
 
 	// Print values always on PostIteration or when ValueInterval has elapsed.
-	printValues := time.Since(p.lastValue) > p.ValueInterval || r == PostIteration
+	printValues := time.Since(p.lastValue) > p.ValueInterval || op == PostIteration
 	if !printValues {
 		// Return early if not printing anything.
 		return nil
 	}
 
 	// Print heading when HeadingInterval lines have been printed, but never on PostIteration.
-	printHeading := p.lastHeading >= p.HeadingInterval && r != PostIteration
+	printHeading := p.lastHeading >= p.HeadingInterval && op != PostIteration
 	if printHeading {
 		p.lastHeading = 1
 	} else {

--- a/printer.go
+++ b/printer.go
@@ -55,20 +55,20 @@ func (p *Printer) Init() error {
 	return nil
 }
 
-func (p *Printer) Record(loc *Location, _ EvaluationType, iter IterationType, stats *Stats) error {
-	if iter != MajorIteration && iter != InitIteration && iter != PostIteration {
+func (p *Printer) Record(loc *Location, r RequestType, stats *Stats) error {
+	if r != MajorIteration && r != InitIteration && r != PostIteration {
 		return nil
 	}
 
 	// Print values always on PostIteration or when ValueInterval has elapsed.
-	printValues := time.Since(p.lastValue) > p.ValueInterval || iter == PostIteration
+	printValues := time.Since(p.lastValue) > p.ValueInterval || r == PostIteration
 	if !printValues {
 		// Return early if not printing anything.
 		return nil
 	}
 
 	// Print heading when HeadingInterval lines have been printed, but never on PostIteration.
-	printHeading := p.lastHeading >= p.HeadingInterval && iter != PostIteration
+	printHeading := p.lastHeading >= p.HeadingInterval && r != PostIteration
 	if printHeading {
 		p.lastHeading = 1
 	} else {

--- a/types.go
+++ b/types.go
@@ -44,20 +44,20 @@ const (
 	HessEvaluation
 
 	// Mask for the evaluating operations.
-	Evaluations = FuncEvaluation | GradEvaluation | HessEvaluation
+	evaluations = FuncEvaluation | GradEvaluation | HessEvaluation
 )
 
-func (op Operation) IsEvaluation() bool {
-	return op&Evaluations != 0 && op&^Evaluations == 0
+func (op Operation) isEvaluation() bool {
+	return op&evaluations != 0 && op&^evaluations == 0
 }
 
 func (op Operation) String() string {
-	if op&Evaluations != 0 {
+	if op&evaluations != 0 {
 		return fmt.Sprintf("Evaluation(Func: %t, Grad: %t, Hess: %t, Extra: 0b%b)",
 			op&FuncEvaluation != 0,
 			op&GradEvaluation != 0,
 			op&HessEvaluation != 0,
-			op&^(Evaluations))
+			op&^(evaluations))
 	}
 	s, ok := operationNames[op]
 	if ok {

--- a/types.go
+++ b/types.go
@@ -115,14 +115,19 @@ type Problem struct {
 	// Func evaluates the objective function at the given location. Func
 	// must not modify x.
 	Func func(x []float64) float64
+
 	// Grad evaluates the gradient at x and stores the result in-place in grad.
 	// Grad must not modify x.
 	Grad func(x []float64, grad []float64)
+
 	// Hess evaluates the Hessian at x and stores the result in-place in hess.
 	// Hess must not modify x.
 	Hess func(x []float64, hess *mat64.SymDense)
-	// Status reports the status of the optimization problem and reports
-	// any error.
+
+	// Status reports the status of the objective function being optimized and any
+	// error. This can be used to terminate early, for example when the function is
+	// not able to evaluate itself. The user can use one of the pre-provided Status
+	// constants, or may call NewStatus to create a custom Status value.
 	Status func() (Status, error)
 }
 

--- a/unconstrained_test.go
+++ b/unconstrained_test.go
@@ -994,6 +994,7 @@ func newVariablyDimensioned(dim int, gradTol float64) unconstrainedTest {
 }
 
 func TestLocal(t *testing.T) {
+	t.Skip("NelderMead has not yet been updated to work correctly with the new Method interface")
 	var tests []unconstrainedTest
 	// Mix of functions with and without Grad() method.
 	tests = append(tests, gradFreeTests...)
@@ -1002,6 +1003,7 @@ func TestLocal(t *testing.T) {
 }
 
 func TestNelderMead(t *testing.T) {
+	t.Skip("NelderMead has not yet been updated to work correctly with the new Method interface")
 	var tests []unconstrainedTest
 	// Mix of functions with and without Grad() method.
 	tests = append(tests, gradFreeTests...)

--- a/unconstrained_test.go
+++ b/unconstrained_test.go
@@ -994,7 +994,6 @@ func newVariablyDimensioned(dim int, gradTol float64) unconstrainedTest {
 }
 
 func TestLocal(t *testing.T) {
-	t.Skip("NelderMead has not yet been updated to work correctly with the new Method interface")
 	var tests []unconstrainedTest
 	// Mix of functions with and without Grad() method.
 	tests = append(tests, gradFreeTests...)
@@ -1003,7 +1002,6 @@ func TestLocal(t *testing.T) {
 }
 
 func TestNelderMead(t *testing.T) {
-	t.Skip("NelderMead has not yet been updated to work correctly with the new Method interface")
 	var tests []unconstrainedTest
 	// Mix of functions with and without Grad() method.
 	tests = append(tests, gradFreeTests...)


### PR DESCRIPTION
A proposal for resolving #103 ~~but still work in progress~~.

* Merged `IterationType` and `EvaluationType` into ~~`RequestType`~~ `Operation`.
* Simplified `Method` interface. It can't be any simpler than this, so if this PR is accepted, further changes are very unlikely.
* The above two modifications ripple through the code and lead at some places to essentially a complete rewrite, most importantly in `LinesearchMethod` and `minimize()`. But the issue at hand is solved, and the code is now much cleaner and more correct. I am ~~quite~~ very happy with the changes (if nobody praises you, you must praise yourself).
* Updated docs, especially for `Method` and `Operation`, although while at it, I updated the docs also at other places, which, as a by-product, resolves issues #29 and #96.

@kortschak @btracey Please take a look.