### PR TITLE
Rename some error variables and update their comments

### DIFF
--- a/backtracking.go
+++ b/backtracking.go
@@ -76,7 +76,7 @@ func (b *Backtracking) Iterate(f, _ float64) (Operation, float64, error) {
 	b.stepSize *= b.Decrease
 	if b.stepSize < minimumBacktrackingStepSize {
 		b.lastOp = NoOperation
-		return b.lastOp, b.stepSize, ErrLinesearchFailure
+		return b.lastOp, b.stepSize, ErrLinesearcherFailure
 	}
 	b.lastOp = FuncEvaluation
 	return b.lastOp, b.stepSize, nil

--- a/bisection.go
+++ b/bisection.go
@@ -143,7 +143,7 @@ func (b *Bisection) Iterate(f, g float64) (Operation, float64, error) {
 func (b *Bisection) nextStep(step float64) (Operation, float64, error) {
 	if b.currStep == step {
 		b.lastOp = NoOperation
-		return b.lastOp, b.currStep, ErrLinesearchFailure
+		return b.lastOp, b.currStep, ErrLinesearcherFailure
 	}
 	b.currStep = step
 	b.lastOp = FuncEvaluation | GradEvaluation

--- a/errors.go
+++ b/errors.go
@@ -10,28 +10,29 @@ var (
 	// ErrInf signifies the initial function value is Inf.
 	ErrInf = errors.New("optimize: initial function value is Inf")
 
-	// ErrGradInf signifies the initial function value is Inf.
-	ErrGradInf = errors.New("optimize: initial gradient is Inf")
-
-	// ErrLinesearchFailure signifies the linesearch has iterated too many
-	// times. This may occur if the gradient tolerance is set too low.
-	ErrLinesearchFailure = errors.New("linesearch: failed to converge")
-
 	// ErrNaN signifies the initial function value is NaN.
 	ErrNaN = errors.New("optimize: initial function value is NaN")
 
-	// ErrGradNaN signifies the initial function value is NaN.
-	ErrGradNaN = errors.New("optimize: initial gradient is NaN")
+	// ErrGradInf signifies that a component of the initial gradient is Inf.
+	ErrGradInf = errors.New("optimize: initial gradient is Inf")
 
-	// ErrNonNegativeStepDirection signifies that the linesearch has received a
-	// step direction in which the gradient is not negative.
-	ErrNonNegativeStepDirection = errors.New("linesearch: projected gradient not negative")
+	// ErrGradNaN signifies that a component of the initial gradient is NaN.
+	ErrGradNaN = errors.New("optimize: initial gradient is NaN")
 
 	// ErrZeroDimensional signifies an optimization was called with an input of length 0.
 	ErrZeroDimensional = errors.New("optimize: zero dimensional input")
 
-	// ErrNoProgress signifies that Linesearch cannot make further progress
-	// because there is no change in location after LinesearchMethod step due
-	// to floating-point arithmetic.
-	ErrNoProgress = errors.New("linesearch: no change in location after linesearch step")
+	// ErrLinesearcherFailure signifies that a Linesearcher has iterated too
+	// many times. This may occur if the gradient tolerance is set too low.
+	ErrLinesearcherFailure = errors.New("linesearch: failed to converge")
+
+	// ErrNonDescentDirection signifies that LinesearchMethod has received a
+	// search direction from a NextDirectioner in which the function is not
+	// decreasing.
+	ErrNonDescentDirection = errors.New("linesearch: non-descent search direction")
+
+	// ErrNoProgress signifies that LinesearchMethod cannot make further
+	// progress because there is no change in location after Linesearcher step
+	// due to floating-point arithmetic.
+	ErrNoProgress = errors.New("linesearch: no change in location after Linesearcher step")
 )

--- a/linesearch.go
+++ b/linesearch.go
@@ -153,7 +153,7 @@ func (ls *LinesearchMethod) initNextLinesearch(loc *Location) (Operation, error)
 
 	projGrad := floats.Dot(loc.Gradient, ls.dir)
 	if projGrad >= 0 {
-		return ls.error(ErrNonNegativeStepDirection)
+		return ls.error(ErrNonDescentDirection)
 	}
 
 	op := ls.Linesearcher.Init(loc.F, projGrad, step)


### PR DESCRIPTION
Closes #124, I went with `ErrNonDescentDirection`, "descent direction" seems more common than "decrease direction".

I also renamed `ErrLinesearchFailure` to `ErrLinesearcherFailure`, slightly updated some error comments and reordered them. 

In an effort towards stabilization of the API we should review the error variables. For example, ErrLinesearcherFailure seems too broad and not very descriptive.

PTAL @btracey 