### PR TITLE
Separate evaluations for Bisection

### DIFF
--- a/bisection.go
+++ b/bisection.go
@@ -13,18 +13,19 @@ import "math"
 type Bisection struct {
 	GradConst float64
 
-	minStep  float64
-	maxStep  float64
-	currStep float64
-
 	initF float64
-	minF  float64
-	maxF  float64
-	f     float64
+	initG float64
 
-	initGrad float64
-	minGrad  float64
-	maxGrad  float64
+	minStep float64
+	minF    float64
+	minG    float64
+
+	maxStep float64
+	maxF    float64
+	maxG    float64
+
+	step float64
+	f    float64
 
 	lastOp Operation
 }
@@ -44,18 +45,19 @@ func (b *Bisection) Init(f, g float64, step float64) Operation {
 		panic("bisection: GradConst not between 0 and 1")
 	}
 
-	b.minStep = 0
-	b.maxStep = math.Inf(1)
-	b.currStep = step
-
 	b.initF = f
-	b.minF = f
-	b.maxF = math.NaN()
-	b.f = math.NaN()
+	b.initG = g
 
-	b.initGrad = g
-	b.minGrad = g
-	b.maxGrad = math.NaN()
+	b.minStep = 0
+	b.minF = f
+	b.minG = g
+
+	b.maxStep = math.Inf(1)
+	b.maxF = math.NaN()
+	b.maxG = math.NaN()
+
+	b.step = step
+	b.f = math.NaN()
 
 	b.lastOp = FuncEvaluation
 	return b.lastOp
@@ -69,7 +71,7 @@ func (b *Bisection) Iterate(f, g float64) (Operation, float64, error) {
 	if b.lastOp == FuncEvaluation {
 		b.f = f
 		b.lastOp = GradEvaluation
-		return b.lastOp, b.currStep, nil
+		return b.lastOp, b.step, nil
 	}
 	f = b.f
 
@@ -83,9 +85,9 @@ func (b *Bisection) Iterate(f, g float64) (Operation, float64, error) {
 	if b.minF < minF {
 		minF = b.minF
 	}
-	if StrongWolfeConditionsMet(f, g, minF, b.initGrad, b.currStep, 0, b.GradConst) {
+	if StrongWolfeConditionsMet(f, g, minF, b.initG, b.step, 0, b.GradConst) {
 		b.lastOp = MajorIteration
-		return b.lastOp, b.currStep, nil
+		return b.lastOp, b.step, nil
 	}
 
 	// Deciding on the next step size
@@ -94,25 +96,25 @@ func (b *Bisection) Iterate(f, g float64) (Operation, float64, error) {
 		switch {
 		case g > 0:
 			// Found a change in derivative sign, so this is the new maximum
-			b.maxStep = b.currStep
+			b.maxStep = b.step
 			b.maxF = f
-			b.maxGrad = g
+			b.maxG = g
 			return b.nextStep((b.minStep + b.maxStep) / 2)
 		case f <= b.minF:
 			// Still haven't found an upper bound, but there is not an increase in
 			// function value and the gradient is still negative, so go more in
 			// that direction.
-			b.minStep = b.currStep
+			b.minStep = b.step
 			b.minF = f
-			b.minGrad = g
-			return b.nextStep(b.currStep * 2)
+			b.minG = g
+			return b.nextStep(b.step * 2)
 		default:
 			// Increase in function value, but the gradient is still negative.
 			// Means we must have skipped over a local minimum, so set this point
 			// as the new maximum
-			b.maxStep = b.currStep
+			b.maxStep = b.step
 			b.maxF = f
-			b.maxGrad = g
+			b.maxG = g
 			return b.nextStep((b.minStep + b.maxStep) / 2)
 		}
 	}
@@ -121,24 +123,24 @@ func (b *Bisection) Iterate(f, g float64) (Operation, float64, error) {
 	// find minimum.
 	if f <= b.minF && f <= b.maxF {
 		if g < 0 {
-			b.minStep = b.currStep
+			b.minStep = b.step
 			b.minF = f
-			b.minGrad = g
+			b.minG = g
 		} else {
-			b.maxStep = b.currStep
+			b.maxStep = b.step
 			b.maxF = f
-			b.maxGrad = g
+			b.maxG = g
 		}
 	} else {
 		// We found a higher point. Want to push toward the minimal bound
 		if b.minF <= b.maxF {
-			b.maxStep = b.currStep
+			b.maxStep = b.step
 			b.maxF = f
-			b.maxGrad = g
+			b.maxG = g
 		} else {
-			b.minStep = b.currStep
+			b.minStep = b.step
 			b.minF = f
-			b.minGrad = g
+			b.minG = g
 		}
 	}
 	return b.nextStep((b.minStep + b.maxStep) / 2)
@@ -150,11 +152,11 @@ func (b *Bisection) Iterate(f, g float64) (Operation, float64, error) {
 // it sets the new step size and returns the evaluation type and the step. If the steps
 // are the same, it returns an error.
 func (b *Bisection) nextStep(step float64) (Operation, float64, error) {
-	if b.currStep == step {
+	if b.step == step {
 		b.lastOp = NoOperation
-		return b.lastOp, b.currStep, ErrLinesearcherFailure
+		return b.lastOp, b.step, ErrLinesearcherFailure
 	}
-	b.currStep = step
+	b.step = step
 	b.lastOp = FuncEvaluation
-	return b.lastOp, b.currStep, nil
+	return b.lastOp, b.step, nil
 }


### PR DESCRIPTION
No work is saved, but with this our Linesearchers don't need oring of Evaluations. Then the last place using it would be LinesearchMethod. @btracey PTAL