### PR TITLE
Rename FuncConst and GradConst in linesearchers

### DIFF
--- a/linesearch.go
+++ b/linesearch.go
@@ -183,9 +183,9 @@ func (ls *LinesearchMethod) initNextLinesearch(loc *Location) (Operation, error)
 // true, though this is not enforced:
 //  - initGrad < 0
 //  - step > 0
-//  - 0 < funcConst < 1
-func ArmijoConditionMet(currObj, initObj, initGrad, step, funcConst float64) bool {
-	return currObj <= initObj+funcConst*step*initGrad
+//  - 0 < decrease < 1
+func ArmijoConditionMet(currObj, initObj, initGrad, step, decrease float64) bool {
+	return currObj <= initObj+decrease*step*initGrad
 }
 
 // StrongWolfeConditionsMet returns true if the strong Wolfe conditions have been met.
@@ -195,12 +195,12 @@ func ArmijoConditionMet(currObj, initObj, initGrad, step, funcConst float64) boo
 // enforced:
 //  - initGrad < 0
 //  - step > 0
-//  - 0 <= funcConst < gradConst < 1
-func StrongWolfeConditionsMet(currObj, currGrad, initObj, initGrad, step, funcConst, gradConst float64) bool {
-	if currObj > initObj+funcConst*step*initGrad {
+//  - 0 <= decrease < curvature < 1
+func StrongWolfeConditionsMet(currObj, currGrad, initObj, initGrad, step, decrease, curvature float64) bool {
+	if currObj > initObj+decrease*step*initGrad {
 		return false
 	}
-	return math.Abs(currGrad) < gradConst*math.Abs(initGrad)
+	return math.Abs(currGrad) < curvature*math.Abs(initGrad)
 }
 
 // WeakWolfeConditionsMet returns true if the weak Wolfe conditions have been met.
@@ -209,10 +209,10 @@ func StrongWolfeConditionsMet(currObj, currGrad, initObj, initGrad, step, funcCo
 // conditions, the following should be true, though this is not enforced:
 //  - initGrad < 0
 //  - step > 0
-//  - 0 <= funcConst < gradConst < 1
-func WeakWolfeConditionsMet(currObj, currGrad, initObj, initGrad, step, funcConst, gradConst float64) bool {
-	if currObj > initObj+funcConst*step*initGrad {
+//  - 0 <= decrease < curvature< 1
+func WeakWolfeConditionsMet(currObj, currGrad, initObj, initGrad, step, decrease, curvature float64) bool {
+	if currObj > initObj+decrease*step*initGrad {
 		return false
 	}
-	return currGrad >= gradConst*initGrad
+	return currGrad >= curvature*initGrad
 }

--- a/linesearcher_test.go
+++ b/linesearcher_test.go
@@ -26,7 +26,7 @@ func TestMoreThuente(t *testing.T) {
 func TestBisection(t *testing.T) {
 	c := 0.1
 	ls := &Bisection{
-		GradConst: c,
+		CurvatureFactor: c,
 	}
 	testLinesearcher(t, ls, 0, c, true)
 }

--- a/linesearcher_test.go
+++ b/linesearcher_test.go
@@ -34,7 +34,7 @@ func TestBisection(t *testing.T) {
 func TestBacktracking(t *testing.T) {
 	d := 0.001
 	ls := &Backtracking{
-		FuncConst: d,
+		DecreaseFactor: d,
 	}
 	testLinesearcher(t, ls, d, 0, false)
 }

--- a/unconstrained_test.go
+++ b/unconstrained_test.go
@@ -1016,7 +1016,7 @@ func TestGradientDescent(t *testing.T) {
 func TestGradientDescentBacktracking(t *testing.T) {
 	testLocal(t, gradientDescentTests, &GradientDescent{
 		Linesearcher: &Backtracking{
-			FuncConst: 0.1,
+			DecreaseFactor: 0.1,
 		},
 	})
 }


### PR DESCRIPTION
Also renamed `Decrease` to `Contraction` in `Backtracking`, not sure if it is a good name. PTAL @btracey 