### PR TITLE
optimize: add example for Local+BFGS

### DIFF
--- a/local_example_test.go
+++ b/local_example_test.go
@@ -1,0 +1,43 @@
+// Copyright ©2016 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package optimize_test
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/gonum/optimize"
+	"github.com/gonum/optimize/functions"
+)
+
+func ExampleLocal_BFGS() {
+	p := optimize.Problem{
+		Func: functions.ExtendedRosenbrock{}.Func,
+		Grad: functions.ExtendedRosenbrock{}.Grad,
+	}
+
+	x := []float64{1.3, 0.7, 0.8, 1.9, 1.2}
+	settings := optimize.DefaultSettings()
+	settings.Recorder = nil
+	settings.GradientThreshold = 1e-12
+	settings.FunctionConverge = nil
+
+	result, err := optimize.Local(p, x, settings, &optimize.BFGS{})
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err = result.Status.Err(); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("result.Status: %v\n", result.Status)
+	fmt.Printf("result.X: %v\n", result.X)
+	fmt.Printf("result.F: %v\n", result.F)
+	fmt.Printf("result.Stats.FuncEvaluations: %d\n", result.Stats.FuncEvaluations)
+	// Output:
+	// result.Status: GradientThreshold
+	// result.X: [1 1 1 1 1]
+	// result.F: 0
+	// result.Stats.FuncEvaluations: 35
+}


### PR DESCRIPTION
This CL adds a simple example, extracted from:
 http://docs.scipy.org/doc/scipy-0.17.0/reference/generated/scipy.optimize.minimize.html#scipy.optimize.minimize